### PR TITLE
Remove unnecessary mv command from helm package step

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -169,7 +169,6 @@ jobs:
           helm package deployment/k8s/charts/aggregates/migrationAssistantWithArgo \
             --version ${{ steps.get_data.outputs.version }} \
             --app-version ${{ steps.get_data.outputs.version }}
-          mv migration-assistant-*.tgz migration-assistant-${{ steps.get_data.outputs.version }}.tgz
       - name: Configure AWS Credentials for Solutions Credentials
         if: ${{ !github.event.act }}
         uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
### Description
Removes the unnecessary `mv migration-assistant-*.tgz migration-assistant-${{ steps.get_data.outputs.version }}.tgz` command from the helm package step in release-drafter.yml. The helm package command already outputs the file with the correct versioned name.

### Issues Resolved
N/A

### Testing
N/A - workflow change only

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).