### PR TITLE
Enable CI testing for orchestrationSpecs TypeScript packages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -265,11 +265,10 @@ jobs:
           - ./deployment/cdk/opensearch-service-migration
           - ./deployment/migration-assistant-solution
           - ./frontend
-          # TODO - get these enabled
-#          - ./orchestrationSpecs/packages/argo-workflow-builders
-#          - ./orchestrationSpecs/packages/config-processor
-#          - ./orchestrationSpecs/packages/migration-workflow-templates
-#          - ./orchestrationSpecs/packages/schemas
+          - ./orchestrationSpecs/packages/argo-workflow-builders
+          - ./orchestrationSpecs/packages/config-processor
+          - ./orchestrationSpecs/packages/migration-workflow-templates
+          - ./orchestrationSpecs/packages/schemas
     defaults:
       run:
         working-directory: ${{ matrix.npm-project }}


### PR DESCRIPTION
This PR enables CI testing for the orchestrationSpecs TypeScript packages that were previously commented out.

## Changes
- Uncommented orchestrationSpecs packages in node-tests matrix in CI.yml
- Enables CI validation for: argo-workflow-builders, config-processor, migration-workflow-templates, schemas

## Why
These 75+ TypeScript files including tests were not being validated in CI, creating regression risk for Kubernetes/Argo workflow generation code.