### PR TITLE
Modernize pre-commit hooks with pre-commit framework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -105,10 +105,18 @@ We use Spotless for code formatting. To check and apply the code style:
 
 ## Pre-Commit Hooks
 
+This project uses the [pre-commit](https://pre-commit.com/) framework for managing git hooks. The configured hooks check for trailing whitespace, proper end-of-file formatting, valid YAML/JSON syntax, and Python code style (flake8).
+
 Install the pre-commit hooks:
 
 ```bash
 ./install_githooks.sh
+```
+
+To manually run all hooks against all files:
+
+```bash
+pre-commit run --all-files
 ```
 
 ## Publishing Images

--- a/install_githooks.sh
+++ b/install_githooks.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-pip3 install flake8==3.7.8
-cp -rf git-hooks/pre-commit .git/hooks
+pip3 install pre-commit
+pre-commit install


### PR DESCRIPTION
This PR modernizes the pre-commit hooks by migrating to the pre-commit framework.

## Changes
- Created .pre-commit-config.yaml with standard hooks (trailing-whitespace, end-of-file-fixer, check-yaml, check-json, flake8)
- Updated install_githooks.sh to use pre-commit framework
- Added setup instructions to DEVELOPER_GUIDE.md

## Why
The current git-hooks/pre-commit only runs flake8. The pre-commit framework enables consistent code quality checks across all file types, catching issues locally before CI.