### PR TITLE
Add CHANGELOG.md for release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.0] - YYYY-MM-DD
+
+### Added
+- Initial release
+
+[Unreleased]: https://github.com/AndreKurait/opensearch-migrations/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/AndreKurait/opensearch-migrations/releases/tag/v0.1.0


### PR DESCRIPTION
Adds a CHANGELOG.md following Keep a Changelog format.

## Changes
- New CHANGELOG.md in repository root
- Follows keepachangelog.com format
- Includes Unreleased section for tracking upcoming changes

## Why
Provides centralized version history for users and contributors to understand upgrade impacts.