### PR TITLE
Add dedicated coordinator cluster support for RFS backfill

### DIFF
--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
@@ -1439,6 +1439,334 @@ spec:
         "inputs": {
           "parameters": [
             {
+              "name": "sessionName",
+            },
+          ],
+        },
+        "name": "createcoordinatorsecret",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "apply",
+          "manifest": "apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{='rfs-coordinator-'+inputs.parameters.sessionName+'-creds'}}"
+  labels:
+    rfs-coordinator: "true"
+    session-name: "{{inputs.parameters.sessionName}}"
+type: Opaque
+stringData:
+  username: admin
+  password: myStrongPassword123!
+",
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "sessionName",
+            },
+          ],
+        },
+        "name": "createcoordinatorservice",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "apply",
+          "manifest": "apiVersion: v1
+kind: Service
+metadata:
+  name: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+  labels:
+    app: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+    rfs-coordinator: "true"
+    session-name: "{{inputs.parameters.sessionName}}"
+spec:
+  selector:
+    app: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+  ports:
+    - name: https
+      port: 9200
+      targetPort: https
+",
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "sessionName",
+            },
+          ],
+        },
+        "name": "createcoordinatorstatefulset",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "apply",
+          "manifest": "apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+  labels:
+    app: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+    rfs-coordinator: "true"
+    session-name: "{{inputs.parameters.sessionName}}"
+spec:
+  serviceName: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+  replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
+  selector:
+    matchLabels:
+      app: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+  template:
+    metadata:
+      labels:
+        app: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+        rfs-coordinator: "true"
+        session-name: "{{inputs.parameters.sessionName}}"
+    spec:
+      serviceAccountName: argo-workflow-executor
+      initContainers:
+        - name: install-plugins
+          image: opensearchproject/opensearch:3.1.0
+          command:
+            - sh
+            - -c
+            - |-
+              set -euo pipefail
+              cp -r /usr/share/opensearch/plugins/* /plugins/ 2>/dev/null || true
+              bin/opensearch-plugin install --batch repository-s3
+              cp -r /usr/share/opensearch/plugins/repository-s3 /plugins/
+          volumeMounts:
+            - name: plugins
+              mountPath: /plugins
+      containers:
+        - name: opensearch
+          image: opensearchproject/opensearch:3.1.0
+          ports:
+            - name: https
+              containerPort: 9200
+          env:
+            - name: cluster.name
+              value: "{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+            - name: discovery.type
+              value: single-node
+            - name: OPENSEARCH_INITIAL_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{='rfs-coordinator-'+inputs.parameters.sessionName+'-creds'}}"
+                  key: username
+            - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{='rfs-coordinator-'+inputs.parameters.sessionName+'-creds'}}"
+                  key: password
+            - name: OPENSEARCH_JAVA_OPTS
+              value: -Xms2g -Xmx2g
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -sk -u "\${OPENSEARCH_INITIAL_ADMIN_USERNAME}:\${OPENSEARCH_INITIAL_ADMIN_PASSWORD}" "https://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 24
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/opensearch/data
+            - name: plugins
+              mountPath: /usr/share/opensearch/plugins
+      volumes:
+        - name: plugins
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+",
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "sessionName",
+            },
+          ],
+        },
+        "name": "deploycoordinatorcluster",
+        "outputs": {
+          "parameters": [],
+        },
+        "steps": [
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "sessionName",
+                    "value": "{{inputs.parameters.sessionName}}",
+                  },
+                ],
+              },
+              "name": "createSecret",
+              "template": "createcoordinatorsecret",
+            },
+          ],
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "sessionName",
+                    "value": "{{inputs.parameters.sessionName}}",
+                  },
+                ],
+              },
+              "name": "createService",
+              "template": "createcoordinatorservice",
+            },
+          ],
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "sessionName",
+                    "value": "{{inputs.parameters.sessionName}}",
+                  },
+                ],
+              },
+              "name": "createStatefulSet",
+              "template": "createcoordinatorstatefulset",
+            },
+          ],
+        ],
+      },
+      {
+        "container": {
+          "args": [
+            "kubectl wait --for=condition=ready pod/{{='rfs-coordinator-'+inputs.parameters.sessionName}}-0 --timeout=300s",
+          ],
+          "command": [
+            "sh",
+            "-c",
+          ],
+          "env": [],
+          "image": "{{inputs.parameters.imageMigrationConsoleLocation}}",
+          "imagePullPolicy": "{{inputs.parameters.imageMigrationConsolePullPolicy}}",
+          "resources": {
+            "limits": {
+              "cpu": "500m",
+              "memory": "2000Mi",
+            },
+            "requests": {
+              "cpu": "500m",
+              "memory": "2000Mi",
+            },
+          },
+        },
+        "inputs": {
+          "parameters": [
+            {
+              "name": "sessionName",
+            },
+            {
+              "name": "imageMigrationConsoleLocation",
+            },
+            {
+              "name": "imageMigrationConsolePullPolicy",
+            },
+          ],
+        },
+        "name": "waitforcoordinatorclusterready",
+        "outputs": {
+          "parameters": [],
+        },
+        "retryStrategy": {
+          "backoff": {
+            "cap": "5",
+            "duration": "5",
+            "factor": "1",
+          },
+          "limit": "60",
+          "retryPolicy": "Always",
+        },
+      },
+      {
+        "container": {
+          "args": [
+            "set -e
+CLUSTER_NAME="{{='rfs-coordinator-'+inputs.parameters.sessionName}}"
+echo "Deleting coordinator cluster: $CLUSTER_NAME"
+kubectl delete statefulset "$CLUSTER_NAME" --ignore-not-found
+kubectl delete service "$CLUSTER_NAME" --ignore-not-found
+kubectl delete secret "$CLUSTER_NAME-creds" --ignore-not-found
+kubectl delete pvc -l app="$CLUSTER_NAME" --ignore-not-found
+echo "Coordinator cluster deleted"",
+          ],
+          "command": [
+            "sh",
+            "-c",
+          ],
+          "env": [],
+          "image": "{{inputs.parameters.imageMigrationConsoleLocation}}",
+          "imagePullPolicy": "{{inputs.parameters.imageMigrationConsolePullPolicy}}",
+          "resources": {
+            "limits": {
+              "cpu": "500m",
+              "memory": "2000Mi",
+            },
+            "requests": {
+              "cpu": "500m",
+              "memory": "2000Mi",
+            },
+          },
+        },
+        "inputs": {
+          "parameters": [
+            {
+              "name": "sessionName",
+            },
+            {
+              "name": "imageMigrationConsoleLocation",
+            },
+            {
+              "name": "imageMigrationConsolePullPolicy",
+            },
+          ],
+        },
+        "name": "deletecoordinatorcluster",
+        "outputs": {
+          "parameters": [],
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
               "name": "sourceVersion",
             },
             {
@@ -1479,10 +1807,39 @@ spec:
           [
             {
               "arguments": {
-                "parameters": [],
+                "parameters": [
+                  {
+                    "name": "sessionName",
+                    "value": "{{inputs.parameters.sessionName}}",
+                  },
+                ],
               },
-              "name": "configureCoordinator",
-              "template": "donothing",
+              "name": "deployCoordinatorCluster",
+              "template": "deploycoordinatorcluster",
+              "when": "{{=!(sprig.dig('useTargetClusterForWorkCoordination', true, fromJSON(inputs.parameters.documentBackfillConfig)))}}",
+            },
+          ],
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "sessionName",
+                    "value": "{{inputs.parameters.sessionName}}",
+                  },
+                  {
+                    "name": "imageMigrationConsoleLocation",
+                    "value": "{{inputs.parameters.imageMigrationConsoleLocation}}",
+                  },
+                  {
+                    "name": "imageMigrationConsolePullPolicy",
+                    "value": "{{inputs.parameters.imageMigrationConsolePullPolicy}}",
+                  },
+                ],
+              },
+              "name": "waitForCoordinatorClusterReady",
+              "template": "waitforcoordinatorclusterready",
+              "when": "{{=!(sprig.dig('useTargetClusterForWorkCoordination', true, fromJSON(inputs.parameters.documentBackfillConfig)))}}",
             },
           ],
           [
@@ -1531,12 +1888,35 @@ spec:
                   },
                   {
                     "name": "coordinatorConfig",
-                    "value": "{{inputs.parameters.targetConfig}}",
+                    "value": "{{=((!(sprig.dig('useTargetClusterForWorkCoordination', true, fromJSON(inputs.parameters.documentBackfillConfig)))) ? (toJSON(sprig.dict("name", 'coordinator', "endpoint", 'https://'+'rfs-coordinator-'+inputs.parameters.sessionName+':9200', "allowInsecure", true, "version", 'OS 3.1', "authConfig", sprig.dict("basic", sprig.dict("secretName", 'rfs-coordinator-'+inputs.parameters.sessionName+'-creds'))))) : (inputs.parameters.targetConfig))}}",
                   },
                 ],
               },
               "name": "runBulkLoad",
               "template": "runbulkload",
+            },
+          ],
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "sessionName",
+                    "value": "{{inputs.parameters.sessionName}}",
+                  },
+                  {
+                    "name": "imageMigrationConsoleLocation",
+                    "value": "{{inputs.parameters.imageMigrationConsoleLocation}}",
+                  },
+                  {
+                    "name": "imageMigrationConsolePullPolicy",
+                    "value": "{{inputs.parameters.imageMigrationConsolePullPolicy}}",
+                  },
+                ],
+              },
+              "name": "deleteCoordinatorCluster",
+              "template": "deletecoordinatorcluster",
+              "when": "{{=!(sprig.dig('useTargetClusterForWorkCoordination', true, fromJSON(inputs.parameters.documentBackfillConfig)))}}",
             },
           ],
         ],

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -195,6 +195,8 @@ export const USER_RFS_OPTIONS = z.object({
     maxConnections: z.number().default(10).optional(),
     maxShardSizeBytes: z.number().default(80*1024*1024*1024).optional(),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional(),
+    useTargetClusterForWorkCoordination: z.boolean().default(true).optional()
+        .describe("When true, uses target cluster for work coordination. When false, deploys a dedicated OS 3.1 coordinator cluster."),
 
     skipApproval: z.boolean().default(false).optional(),  // TODO - fullmigration
     resources: z.preprocess((v) =>

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -493,6 +493,10 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "type": "string",
                             "default": "http://otel-collector:4317"
                           },
+                          "useTargetClusterForWorkCoordination": {
+                            "type": "boolean",
+                            "default": true
+                          },
                           "resources": {
                             "type": "object",
                             "nullable": true,
@@ -1153,6 +1157,11 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "otelCollectorEndpoint": {
                             "type": "string",
                             "default": "http://otel-collector:4317"
+                          },
+                          "useTargetClusterForWorkCoordination": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "When true, uses target cluster for work coordination. When false, deploys a dedicated OS 3.1 coordinator cluster."
                           },
                           "skipApproval": {
                             "type": "boolean",


### PR DESCRIPTION
### Description
Extends coordinator cluster support to deploy and manage a dedicated OS 3.1 single-node cluster for work coordination when `useTargetClusterForWorkCoordination` is `false`.

**Changes:**
- Added `useTargetClusterForWorkCoordination` flag to `USER_RFS_OPTIONS` schema (default: `true`)
- Created new templates in `documentBulkLoad.ts`:
  - `deployCoordinatorCluster` - deploys OS 3.1 cluster (Secret, Service, StatefulSet)
  - `waitForCoordinatorClusterReady` - polls for pod readiness
  - `deleteCoordinatorCluster` - cleanup after backfill
- Updated `setupAndRunBulkLoad` to conditionally deploy coordinator cluster
- Coordinator naming uses `rfs-coordinator-` prefix to avoid conflicts with target clusters

**Behavior:**
- When `useTargetClusterForWorkCoordination: true` (default): No change, uses target cluster
- When `useTargetClusterForWorkCoordination: false`: Deploys dedicated OS 3.1 coordinator, cleans up after backfill

### Issues Resolved
N/A - Feature implementation

### Testing
- TypeScript type-check passes
- All snapshot tests updated and passing
- Generated workflow YAML includes coordinator deployment templates
- No behavior change when `useTargetClusterForWorkCoordination: true` (default)

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).