### PR TITLE
Add pre-install hook for migration console NodePool

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
@@ -41,6 +41,10 @@ apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: dedicated-small-instance-migration-console-pool
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   limits:
     cpu: 4000m


### PR DESCRIPTION
## Why
When the EKS NodePool manifest is invalid (e.g., due to schema mismatch), the install currently fails after several resources have already been created.

## What
Adds Helm pre-install/pre-upgrade hook annotations to the migration console dedicated NodePool so failures happen before the rest of the release resources are applied.

## Notes
- This is intended to improve fail-fast behavior for the MA chart on EKS/Karpenter.
- Hook delete policy is set to `before-hook-creation` to avoid duplicate hook resources across upgrades.