### PR TITLE
Fix Karpenter NodePool disruption field nesting

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
@@ -45,6 +45,9 @@ spec:
   limits:
     cpu: 4000m
     memory: 4Gi
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m  # No reason to wait long if the console exits
   template:
     spec:
       nodeClassRef:
@@ -70,9 +73,6 @@ spec:
         - key: "migration-console" # Taint to ensure only migration console pods land here
           value: "dedicated"
           effect: NoSchedule
-    disruption:
-      consolidationPolicy: WhenEmpty
-      consolidateAfter: 5m  # No reason to wait long if the console exits
 ---
 {{- end }}
 {{ $sharedLogsVolumeEnabled := .Values.logs.sharedLogsVolume.enabled }}


### PR DESCRIPTION
## Why
The migration console NodePool currently renders `spec.template.disruption`, which is rejected by Karpenter v1 schema validation (expects `spec.disruption`). This causes the MA Helm release to fail on EKS.

## What
Moves `disruption` from under `spec.template` to `spec.disruption` in the migration console dedicated NodePool manifest.

## Validation
Rendered chart (`helm template`) shows `spec.disruption` in the NodePool.