### PR TITLE
Replace custom Bedrock agent with kiro-cli

### DIFF
--- a/test/kiroSopTest/evaluate.py
+++ b/test/kiroSopTest/evaluate.py
@@ -23,7 +23,10 @@ def evaluate(namespace: str = "ma") -> dict:
 
     # 1. Workflow Completion (40 pts)
     log.info("Evaluating workflow completion...")
-    wf = run_bash(f"kubectl exec migration-console-0 -n {namespace} -- bash -c 'source /.venv/bin/activate && workflow status --all' 2>&1")
+    wf = run_bash(
+        f"kubectl exec migration-console-0 -n {namespace} -- "
+        f"bash -c 'source /.venv/bin/activate && workflow status --all' 2>&1"
+    )
     if "Succeeded" in wf["output"]:
         scores["workflow_completion"] = 40
     elif "Running" in wf["output"]:
@@ -34,11 +37,27 @@ def evaluate(namespace: str = "ma") -> dict:
 
     # 2. Data Integrity (30 pts)
     log.info("Evaluating data integrity...")
-    src = run_bash(f"kubectl exec migration-console-0 -n {namespace} -- bash -c 'source /.venv/bin/activate && console clusters curl source_cluster /_cat/indices?format=json' 2>&1")
-    tgt = run_bash(f"kubectl exec migration-console-0 -n {namespace} -- bash -c 'source /.venv/bin/activate && console clusters curl target_cluster /_cat/indices?format=json' 2>&1")
+    src = run_bash(
+        f"kubectl exec migration-console-0 -n {namespace} -- "
+        f"bash -c 'source /.venv/bin/activate && "
+        f"console clusters curl source_cluster /_cat/indices?format=json' 2>&1"
+    )
+    tgt = run_bash(
+        f"kubectl exec migration-console-0 -n {namespace} -- "
+        f"bash -c 'source /.venv/bin/activate && "
+        f"console clusters curl target_cluster /_cat/indices?format=json' 2>&1"
+    )
     try:
-        src_indices = {i["index"]: int(i["docs.count"]) for i in json.loads(src["output"]) if not i["index"].startswith(".")}
-        tgt_indices = {i["index"]: int(i["docs.count"]) for i in json.loads(tgt["output"]) if not i["index"].startswith(".")}
+        src_indices = {
+            i["index"]: int(i["docs.count"])
+            for i in json.loads(src["output"])
+            if not i["index"].startswith(".")
+        }
+        tgt_indices = {
+            i["index"]: int(i["docs.count"])
+            for i in json.loads(tgt["output"])
+            if not i["index"].startswith(".")
+        }
         if src_indices:
             matched = sum(1 for idx, cnt in src_indices.items() if tgt_indices.get(idx) == cnt)
             scores["data_integrity"] = round(matched / len(src_indices) * 30)

--- a/test/kiroSopTest/evaluate.py
+++ b/test/kiroSopTest/evaluate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Evaluate migration results after kiro-cli run."""
+import argparse
+import json
+import logging
+import subprocess
+import sys
+
+logging.basicConfig(format="%(asctime)s [%(levelname)s] %(message)s", level=logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def run_bash(command: str, timeout: int = 300) -> dict:
+    try:
+        r = subprocess.run(["bash", "-lc", command], capture_output=True, text=True, timeout=timeout)
+        return {"exit_code": r.returncode, "output": r.stdout + r.stderr}
+    except Exception as e:
+        return {"exit_code": 1, "output": str(e)}
+
+
+def evaluate(namespace: str = "ma") -> dict:
+    scores = {}
+
+    # 1. Workflow Completion (40 pts)
+    log.info("Evaluating workflow completion...")
+    wf = run_bash(f"kubectl exec migration-console-0 -n {namespace} -- bash -c 'source /.venv/bin/activate && workflow status --all' 2>&1")
+    if "Succeeded" in wf["output"]:
+        scores["workflow_completion"] = 40
+    elif "Running" in wf["output"]:
+        scores["workflow_completion"] = 20
+    else:
+        scores["workflow_completion"] = 0
+    log.info(f"  Workflow: {scores['workflow_completion']}/40")
+
+    # 2. Data Integrity (30 pts)
+    log.info("Evaluating data integrity...")
+    src = run_bash(f"kubectl exec migration-console-0 -n {namespace} -- bash -c 'source /.venv/bin/activate && console clusters curl source_cluster /_cat/indices?format=json' 2>&1")
+    tgt = run_bash(f"kubectl exec migration-console-0 -n {namespace} -- bash -c 'source /.venv/bin/activate && console clusters curl target_cluster /_cat/indices?format=json' 2>&1")
+    try:
+        src_indices = {i["index"]: int(i["docs.count"]) for i in json.loads(src["output"]) if not i["index"].startswith(".")}
+        tgt_indices = {i["index"]: int(i["docs.count"]) for i in json.loads(tgt["output"]) if not i["index"].startswith(".")}
+        if src_indices:
+            matched = sum(1 for idx, cnt in src_indices.items() if tgt_indices.get(idx) == cnt)
+            scores["data_integrity"] = round(matched / len(src_indices) * 30)
+        else:
+            scores["data_integrity"] = 0
+    except Exception:
+        scores["data_integrity"] = 0
+    log.info(f"  Data: {scores['data_integrity']}/30")
+
+    # 3. SOP Compliance (20 pts)
+    log.info("Evaluating SOP compliance...")
+    compliance = 0
+    for artifact in ["plan.md", "run-log.md", "summary.md"]:
+        check = run_bash(f"find .agents/migration/ -name '{artifact}' 2>/dev/null | head -1")
+        if check["output"].strip():
+            compliance += 5
+    if run_bash("ls -la .agents/migration/ 2>/dev/null")["exit_code"] == 0:
+        compliance += 5
+    scores["sop_compliance"] = compliance
+    log.info(f"  SOP Compliance: {compliance}/20")
+
+    # 4. Efficiency (10 pts)
+    scores["efficiency"] = 10 if scores["workflow_completion"] == 40 else 0
+    log.info(f"  Efficiency: {scores['efficiency']}/10")
+
+    scores["total"] = sum(scores.values())
+    log.info(f"TOTAL SCORE: {scores['total']}/100")
+    return scores
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--namespace", default="ma")
+    p.add_argument("--output", default="sop-test-report.json")
+    p.add_argument("--min-score", type=int, default=70)
+    args = p.parse_args()
+
+    scores = evaluate(args.namespace)
+    report = {"scores": scores, "pass": scores["total"] >= args.min_score}
+
+    with open(args.output, "w") as f:
+        json.dump(report, f, indent=2)
+    log.info(f"Report written to {args.output}")
+
+    print(f"\n{'='*60}\nSOP TEST REPORT\n{'='*60}")
+    for k, v in scores.items():
+        print(f"  {k}: {v}")
+    print(f"\n  PASS: {report['pass']} (min: {args.min_score})\n{'='*60}")
+
+    sys.exit(0 if report["pass"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/kiroSopTest/run_agent.py
+++ b/test/kiroSopTest/run_agent.py
@@ -126,7 +126,11 @@ def run_agent(model_id: str, system_prompt: str, user_prompt: str, region: str) 
             if "MIGRATION_COMPLETE" in text or "MIGRATION_FAILED" in text:
                 break
             # Agent stopped but didn't signal completion - nudge it
-            nudge = {"role": "user", "content": [{"text": "Continue. If migration is done, verify results and output MIGRATION_COMPLETE or MIGRATION_FAILED: <reason>."}]}
+            nudge_text = (
+                "Continue. If migration is done, verify results and output "
+                "MIGRATION_COMPLETE or MIGRATION_FAILED: <reason>."
+            )
+            nudge = {"role": "user", "content": [{"text": nudge_text}]}
             messages.append(nudge)
             all_messages.append(nudge)
             continue
@@ -288,9 +292,11 @@ ENVIRONMENT STATUS:
 CRITICAL WORKFLOW SETUP (do this before using console/workflow commands):
 1. Get S3/snapshot config: kubectl get configmap migrations-default-s3-config -n {args.namespace} -o yaml
 2. Build and load workflow config JSON via: workflow configure edit --stdin
-3. After workflow is configured, seed test data on source using console clusters curl (since run-test-benchmarks does NOT work with SigV4 clusters). Example:
-   console clusters curl source_cluster /test-index/_bulk -X POST -H 'Content-Type: application/x-ndjson' --data-binary '<ndjson>'
-   Create at least 2-3 indices with 100+ docs each so the migration has real data to validate against.
+3. After workflow is configured, seed test data on source using console clusters curl
+   (since run-test-benchmarks does NOT work with SigV4 clusters). Example:
+   console clusters curl source_cluster /test-index/_bulk -X POST \\
+     -H 'Content-Type: application/x-ndjson' --data-binary '<ndjson>'
+   Create at least 2-3 indices with 100+ docs each so the migration has real data.
 4. Then run the full migration workflow
 
 Begin the migration now. Do not ask any questions."""

--- a/test/kiroSopTest/setup_kiro_auth.py
+++ b/test/kiroSopTest/setup_kiro_auth.py
@@ -14,7 +14,13 @@ DB_PATH = os.path.expanduser("~/.local/share/kiro-cli/data.sqlite3")
 def main():
     # Get credentials from secrets manager
     result = subprocess.run(
-        ["aws", "secretsmanager", "get-secret-value", "--secret-id", SECRET_ID, "--region", REGION, "--query", "SecretString", "--output", "text"],
+        [
+            "aws", "secretsmanager", "get-secret-value",
+            "--secret-id", SECRET_ID,
+            "--region", REGION,
+            "--query", "SecretString",
+            "--output", "text"
+        ],
         capture_output=True, text=True
     )
     if result.returncode != 0:
@@ -31,7 +37,10 @@ def main():
     c = conn.cursor()
     c.execute("CREATE TABLE IF NOT EXISTS auth_kv (key TEXT PRIMARY KEY, value TEXT)")
     for key, value in creds.items():
-        c.execute("INSERT OR REPLACE INTO auth_kv (key, value) VALUES (?, ?)", (key, json.dumps(value)))
+        c.execute(
+            "INSERT OR REPLACE INTO auth_kv (key, value) VALUES (?, ?)",
+            (key, json.dumps(value))
+        )
     conn.commit()
     conn.close()
 

--- a/test/kiroSopTest/setup_kiro_auth.py
+++ b/test/kiroSopTest/setup_kiro_auth.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Setup kiro-cli auth from AWS Secrets Manager."""
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+
+SECRET_ID = "kiro-cli-creds-temp"
+REGION = "us-east-1"
+DB_PATH = os.path.expanduser("~/.local/share/kiro-cli/data.sqlite3")
+
+
+def main():
+    # Get credentials from secrets manager
+    result = subprocess.run(
+        ["aws", "secretsmanager", "get-secret-value", "--secret-id", SECRET_ID, "--region", REGION, "--query", "SecretString", "--output", "text"],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"Failed to get secret: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    creds = json.loads(result.stdout.strip())
+
+    # Create directory if needed
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+
+    # Setup sqlite database
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("CREATE TABLE IF NOT EXISTS auth_kv (key TEXT PRIMARY KEY, value TEXT)")
+    for key, value in creds.items():
+        c.execute("INSERT OR REPLACE INTO auth_kv (key, value) VALUES (?, ?)", (key, json.dumps(value)))
+    conn.commit()
+    conn.close()
+
+    print(f"kiro-cli auth configured at {DB_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Replaces the custom Bedrock Converse API agent with the real kiro-cli for running the migration SOP test.

## Changes
- Add `Install kiro-cli` stage to download and install kiro-cli binary
- Add `Setup kiro-cli Auth` stage using secrets manager credentials (`kiro-cli-creds-temp`)
- Replace `run_agent.py` with `kiro-cli chat` command using the `opensearch-migration` agent
- Add separate `Evaluate Results` stage for scoring
- Create `evaluate.py` for standalone evaluation after kiro-cli run
- Create `setup_kiro_auth.py` to configure kiro-cli auth from AWS Secrets Manager
- Remove MODEL_ID parameter (kiro-cli uses its own model config from agent definition)
- Archive `kiro-cli-output.log` alongside test reports

## Testing
This PR should be tested by running the kiro-sop-test Jenkins job.

## Related
Built on top of PR #2216