### PR TITLE
Migrate EKS infra to @aws-cdk/aws-eks-v2-alpha L2 construct

### DIFF
--- a/deployment/migration-assistant-solution/lib/solutions-stack-eks.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack-eks.ts
@@ -162,7 +162,7 @@ export class SolutionsInfrastructureEKSStack extends Stack {
             "AWS_ACCOUNT": this.account,
             "AWS_CFN_REGION": this.region,
             "VPC_ID": vpc.vpcId,
-            "EKS_CLUSTER_SECURITY_GROUP": eksInfra.cluster.attrClusterSecurityGroupId.toString(),
+            "EKS_CLUSTER_SECURITY_GROUP": eksInfra.cluster.clusterSecurityGroupId,
             "SNAPSHOT_ROLE": eksInfra.snapshotRole.roleArn.toString(),
             "STAGE": stageParameter.valueAsString
         })

--- a/deployment/migration-assistant-solution/package-lock.json
+++ b/deployment/migration-assistant-solution/package-lock.json
@@ -9,9 +9,10 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.186.0-alpha.0",
+        "@aws-cdk/aws-eks-v2-alpha": "2.239.0-alpha.0",
+        "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.239.0-alpha.0",
         "@jest/globals": "^30.2.0",
-        "cdk": "2.1105.0",
+        "cdk": "2.1106.1",
         "globals": "^17.3.0",
         "source-map-support": "^0.5.21"
       },
@@ -21,9 +22,9 @@
         "@types/eslint__js": "^9.14.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.2.2",
-        "aws-cdk": "2.1105.0",
-        "aws-cdk-lib": "2.237.1",
-        "constructs": "10.4.5",
+        "aws-cdk": "2.1106.1",
+        "aws-cdk-lib": "2.239.0",
+        "constructs": "^10.5.0",
         "eslint": "^9.38.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6",
@@ -74,16 +75,42 @@
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
       "license": "Apache-2.0"
     },
-    "node_modules/@aws-cdk/aws-servicecatalogappregistry-alpha": {
-      "version": "2.186.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalogappregistry-alpha/-/aws-servicecatalogappregistry-alpha-2.186.0-alpha.0.tgz",
-      "integrity": "sha512-x7dRT1XbLkU9LkchD9hwluic3eukbewBXBSQSN+aX6aPXXLt2PQ0PXJDZx+WpSKf9JErvUZN1dr67GFurepUJg==",
+    "node_modules/@aws-cdk/aws-eks-v2-alpha": {
+      "version": "2.239.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-eks-v2-alpha/-/aws-eks-v2-alpha-2.239.0-alpha.0.tgz",
+      "integrity": "sha512-yJuBsRFlWhfSMWMw8/TrspyRIHVcQolwxJLkA9faq97NDe26UdMNgl2Ys2LeSl7Z9hDGa4GomC5tKivcY8HQgQ==",
+      "bundleDependencies": [
+        "yaml"
+      ],
+      "dependencies": {
+        "yaml": "1.10.2"
+      },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.186.0",
-        "constructs": "^10.0.0"
+        "aws-cdk-lib": "^2.239.0",
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-eks-v2-alpha/node_modules/yaml": {
+      "version": "1.10.2",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@aws-cdk/aws-servicecatalogappregistry-alpha": {
+      "version": "2.239.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalogappregistry-alpha/-/aws-servicecatalogappregistry-alpha-2.239.0-alpha.0.tgz",
+      "integrity": "sha512-Sn88pikT4PdiBStijW908G46qXqnfUM7Lz2gNgJE6VfuMNDc8Yl0hnzcM35EJnT9cEbKj8WdZCX6+f17psvQRw==",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.239.0",
+        "constructs": "^10.5.0"
       }
     },
     "node_modules/@aws-cdk/cfnspec": {
@@ -97,17 +124,16 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "48.20.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.20.0.tgz",
-      "integrity": "sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==",
+      "version": "50.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-50.4.0.tgz",
+      "integrity": "sha512-9Cplwc5C+SNe3hMfqZET7gXeM68tiH2ytQytCi+zz31Bn7O3GAgAnC2dYe+HWnZAgVH788ZkkBwnYXkeqx7v4g==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.2"
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -122,7 +148,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.7.3",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2213,10 +2239,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1105.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1105.0.tgz",
-      "integrity": "sha512-1RY2UZJv31XYobEGFHQEb7c2HXNzDbHuHqdnfdYyygvZW4Nrm8MJCW42lqItQCn+wF52Ixc7r2VR5eR4YGtVhA==",
-      "license": "Apache-2.0",
+      "version": "2.1106.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1106.1.tgz",
+      "integrity": "sha512-oSKAvM6a5dVNb+OZoLyjLe2rIkG6URVRHN+cOUZM9uEScYDYPn2KpOQ1iGofH6szsJp76GqQqpiwEpaYXrIHmw==",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -2225,11 +2250,12 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.237.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.237.1.tgz",
-      "integrity": "sha512-RH8mWHLBtc14stkeUF0gFLaWdS5iS2AHUHnoT5B5LLZfEkYP9G43LjJs0AMmpdlQ5/ZQVvCZ+VB83Q9vLxILRw==",
+      "version": "2.239.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.239.0.tgz",
+      "integrity": "sha512-0qpYrE4HL6yRaQriRukfX7m82vNj3otce6v4Y5qK859ILdZBCaz/wqqYgdTnFh6LcA11GAg/Y8l8a+j/VtczyA==",
       "bundleDependencies": [
         "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
         "case",
         "fs-extra",
         "ignore",
@@ -2241,11 +2267,11 @@
         "yaml",
         "mime-types"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^48.20.0",
+        "@aws-cdk/cloud-assembly-api": "^2.0.1",
+        "@aws-cdk/cloud-assembly-schema": "^50.3.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -2254,7 +2280,7 @@
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "table": "^6.9.0",
         "yaml": "1.10.2"
       },
@@ -2262,7 +2288,45 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "constructs": "^10.0.0"
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.0.1",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=50.3.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.7.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -2271,7 +2335,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.18.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2493,7 +2557,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2798,12 +2862,11 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk": {
-      "version": "2.1105.0",
-      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.1105.0.tgz",
-      "integrity": "sha512-AFUU3G9MGizBl5QvGnHcx22y4e6fyG671ZGRER59ZDxAIVp9L9/iJwaHW/VxBCsTESrLxTyfmhD8LxX07hBqAg==",
-      "license": "Apache-2.0",
+      "version": "2.1106.1",
+      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.1106.1.tgz",
+      "integrity": "sha512-q7/xqtXC9qT9J1zP9YuP9Ch42cNa+B1zXI/FsqYSeIyddGCSmEJv04GCUj5wNTEmKsAOxFwYp6VLZDNhTEKdlA==",
       "dependencies": {
-        "aws-cdk": "2.1105.0"
+        "aws-cdk": "2.1106.1"
       },
       "bin": {
         "cdk": "bin/cdk"
@@ -2945,10 +3008,9 @@
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.5.tgz",
-      "integrity": "sha512-fOoP70YLevMZr5avJHx2DU3LNYmC6wM8OwdrNewMZou1kZnPGOeVzBrRjZNgFDHUlulYUjkpFRSpTE3D+n+ZSg==",
-      "license": "Apache-2.0"
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
+      "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg=="
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",

--- a/deployment/migration-assistant-solution/package.json
+++ b/deployment/migration-assistant-solution/package.json
@@ -22,9 +22,9 @@
     "@types/eslint__js": "^9.14.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.2.2",
-    "aws-cdk": "2.1105.0",
-    "aws-cdk-lib": "2.237.1",
-    "constructs": "10.4.5",
+    "aws-cdk": "2.1106.1",
+    "aws-cdk-lib": "2.239.0",
+    "constructs": "^10.5.0",
     "eslint": "^9.38.0",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.6",
@@ -33,9 +33,10 @@
     "typescript-eslint": "^8.54.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.186.0-alpha.0",
+    "@aws-cdk/aws-eks-v2-alpha": "2.239.0-alpha.0",
+    "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.239.0-alpha.0",
     "@jest/globals": "^30.2.0",
-    "cdk": "2.1105.0",
+    "cdk": "2.1106.1",
     "globals": "^17.3.0",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
## Summary

Replaces the L1 `CfnCluster` with the L2 `eks.Cluster` from `@aws-cdk/aws-eks-v2-alpha`, which natively supports EKS Auto Mode. This removes ~50 lines of manual role and config boilerplate that the L2 handles automatically.

## Changes

**eks-infra.ts:**
- `CfnCluster` → `eks.Cluster` from `@aws-cdk/aws-eks-v2-alpha`
- Removed manual `clusterRole` (with 5 managed policies + sts:TagSession) — L2 creates this automatically
- Removed manual `ec2NodeRole` (with 3 managed policies) — L2 creates this automatically
- Removed manual `computeConfig`, `storageConfig`, `kubernetesNetworkConfig` — Auto Mode is the default
- EKS version: 1.32 → 1.34
- Kept `CfnPodIdentityAssociation` as L1 (the L2 alternative requires the kubectl Lambda handler)

**solutions-stack-eks.ts:**
- `cluster.attrClusterSecurityGroupId` → `cluster.clusterSecurityGroupId`

**package.json:**
- `aws-cdk-lib`: 2.237.1 → 2.239.0
- `aws-cdk`/`cdk`: 2.1105.0 → 2.1106.1
- `constructs`: 10.4.5 → ^10.5.0
- Added `@aws-cdk/aws-eks-v2-alpha`: 2.239.0-alpha.0
- `@aws-cdk/aws-servicecatalogappregistry-alpha`: 2.186.0 → 2.239.0-alpha.0

## Note

`@aws-cdk/aws-eks-v2-alpha` is in developer preview. The API may change between CDK releases, but it's actively maintained and is the recommended path forward for EKS Auto Mode in CDK.