### PR TITLE
Add OpenAPI descriptions to user schemas and expose missing Java CLI parameters

### DIFF
--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -233,16 +233,7 @@ export const USER_PROXY_PROCESS_OPTIONS = z.object({
         .describe("URI path pattern to suppress from capture. Requests matching this path are forwarded but not recorded."),
     suppressMethodAndPath: z.string().default("").optional()
         .describe("Combined method and path pattern for capture suppression in 'METHOD /path' format."),
-}).describe("Process-level configuration options for the capture proxy application. These are passed as command-line arguments to the proxy container.")
-.superRefine((data, ctx) => {
-    if (data.sslConfigFile && data.tls) {
-        ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "sslConfigFile and tls are mutually exclusive. Use tls for Kubernetes deployments or sslConfigFile for legacy non-Kubernetes deployments.",
-            path: ['tls']
-        });
-    }
-});
+}).describe("Process-level configuration options for the capture proxy application. These are passed as command-line arguments to the proxy container.");
 
 export const USER_PROXY_WORKFLOW_OPTION_KEYS = getZodKeys(USER_PROXY_WORKFLOW_OPTIONS);
 export const USER_PROXY_PROCESS_OPTION_KEYS = getZodKeys(USER_PROXY_PROCESS_OPTIONS);
@@ -250,6 +241,14 @@ export const USER_PROXY_PROCESS_OPTION_KEYS = getZodKeys(USER_PROXY_PROCESS_OPTI
 export const USER_PROXY_OPTIONS = z.object({
     ...USER_PROXY_WORKFLOW_OPTIONS.shape,
     ...USER_PROXY_PROCESS_OPTIONS.shape,
+}).superRefine((data, ctx) => {
+    if (data.sslConfigFile && data.tls) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "sslConfigFile and tls are mutually exclusive. Use tls for Kubernetes deployments or sslConfigFile for legacy non-Kubernetes deployments.",
+            path: ['tls']
+        });
+    }
 });
 
 export const USER_REPLAYER_WORKFLOW_OPTIONS = z.object({

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -317,6 +317,10 @@ export const USER_CREATE_SNAPSHOT_PROCESS_OPTIONS = z.object({
         .describe("List of index name patterns to include in the snapshot. An empty list means all indices are included."),
     maxSnapshotRateMbPerNode: z.number().default(0).optional()
         .describe("Maximum snapshot throughput in MB/s per data node. 0 means no rate limiting. Use to reduce I/O impact on the source cluster during snapshot creation."),
+    compressionEnabled: z.boolean().default(false).optional()
+        .describe("When true, enables metadata compression for the snapshot. Reduces snapshot size at the cost of slightly increased CPU usage during creation."),
+    includeGlobalState: z.boolean().default(true).optional()
+        .describe("When true, includes cluster global state (persistent settings, templates, etc.) in the snapshot."),
 }).describe("Process-level options for the CreateSnapshot command, controlling which indices are snapshotted and rate limiting.");
 
 export const USER_CREATE_SNAPSHOT_WORKFLOW_OPTION_KEYS = getZodKeys(USER_CREATE_SNAPSHOT_WORKFLOW_OPTIONS);
@@ -361,6 +365,10 @@ export const USER_METADATA_PROCESS_OPTIONS = z.object({
         .describe("Output format for the metadata migration evaluation report. 'HUMAN_READABLE' for formatted text, 'JSON' for machine-parseable output."),
     transformerConfigBase64: z.string().default("").optional()
         .describe("Base64-encoded JSON configuration for metadata transformers. Defines custom transformations applied to index mappings and settings during migration."),
+    transformerConfig: z.string().optional()
+        .describe("Inline JSON configuration for metadata transformers. Keys are transformer names and values are their configuration. Alternative to transformerConfigBase64 for simple configurations."),
+    transformerConfigFile: z.string().optional()
+        .describe("Path to a JSON file containing metadata transformer configuration. The file is read from the container filesystem."),
 }).describe("Process-level options for the metadata migration command, controlling which metadata is migrated and how it is transformed.");
 
 export const USER_METADATA_WORKFLOW_OPTION_KEYS = getZodKeys(USER_METADATA_WORKFLOW_OPTIONS);
@@ -403,8 +411,14 @@ export const USER_RFS_PROCESS_OPTIONS = z.object({
         .describe("When true, allows document migration between clusters with non-exact version compatibility."),
     docTransformerConfigBase64: z.string().default("").optional()
         .describe("Base64-encoded JSON configuration for document transformers. Defines custom transformations applied to each document during the backfill (e.g. field renaming, type conversion)."),
+    docTransformerConfig: z.string().optional()
+        .describe("Inline JSON configuration for document transformers. Keys are transformer names and values are their configuration. Alternative to docTransformerConfigBase64 for simple configurations."),
+    docTransformerConfigFile: z.string().optional()
+        .describe("Path to a JSON file containing document transformer configuration. The file is read from the container filesystem."),
     documentsPerBulkRequest: z.number().default(0x7fffffff).optional()
         .describe("Maximum number of documents per bulk indexing request to the target cluster. Lower values reduce per-request latency but increase overhead."),
+    documentsSizePerBulkRequest: z.number().default(10*1024*1024).optional()
+        .describe("Maximum aggregate document size in bytes per bulk indexing request. Does not apply to single-document requests."),
     initialLeaseDuration: z.string().default("PT1H").optional()
         .describe("ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up."),
     maxConnections: z.number().default(10).optional()
@@ -413,6 +427,20 @@ export const USER_RFS_PROCESS_OPTIONS = z.object({
         .describe("Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
         .describe("URL for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."),
+    serverGeneratedIds: z.union(["AUTO", "ALWAYS", "NEVER"].map(s=>z.literal(s))).default("AUTO").optional()
+        .describe("Controls document ID generation on the target. " +
+            "'AUTO': auto-detect serverless TIMESERIES/VECTOR collections and enable server-generated IDs. " +
+            "'ALWAYS': always use server-generated IDs (discards source IDs). " +
+            "'NEVER': always preserve source document IDs (may fail on serverless TIMESERIES/VECTOR collections)."),
+    allowedDocExceptionTypes: z.array(z.string()).default([]).optional()
+        .describe("List of document-level exception types to treat as successful operations during bulk migration. " +
+            "Enables idempotent migrations by allowing specific errors (e.g. 'version_conflict_engine_exception') to be treated as success rather than failure."),
+    coordinatorRetryMaxRetries: z.number().default(7).optional()
+        .describe("Maximum number of retries when marking work items as completed on the coordinator."),
+    coordinatorRetryInitialDelayMs: z.number().default(1000).optional()
+        .describe("Initial delay in milliseconds for coordinator completion retries. Doubles with each attempt up to coordinatorRetryMaxDelayMs."),
+    coordinatorRetryMaxDelayMs: z.number().default(64000).optional()
+        .describe("Maximum delay in milliseconds for any single coordinator completion retry."),
 }).describe("Process-level options for the RFS document backfill command, controlling indexing behavior, concurrency, and transformations.");
 
 export const USER_RFS_WORKFLOW_OPTION_KEYS = getZodKeys(USER_RFS_WORKFLOW_OPTIONS);

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -281,14 +281,10 @@ export const USER_REPLAYER_PROCESS_OPTIONS = z.object({
         .describe("Inline request transformer configuration as a JSON string. Defines transformations applied to each request before replaying to the target."),
     transformerConfigEncoded: z.string().optional()
         .describe("Base64-encoded request transformer configuration. Alternative to transformerConfig for configurations containing special characters."),
-    transformerConfigFile: z.string().optional()
-        .describe("Path to a JSON file containing request transformer configuration. The file is read from the container filesystem."),
     tupleTransformerConfig: z.string().optional()
         .describe("Inline tuple transformer configuration as a JSON string. Tuple transformers operate on request-response pairs for stateful transformations."),
     tupleTransformerConfigBase64: z.string().optional()
         .describe("Base64-encoded tuple transformer configuration."),
-    tupleTransformerConfigFile: z.string().optional()
-        .describe("Path to a JSON file containing tuple transformer configuration."),
     userAgent: z.string().optional()
         .describe("String appended to the User-Agent header on all replayed requests to the target cluster. Useful for identifying replayed traffic in target cluster logs."),
 }).describe("Process-level configuration options for the traffic replayer application. These control how captured traffic is consumed from Kafka and replayed to the target cluster.");
@@ -367,8 +363,6 @@ export const USER_METADATA_PROCESS_OPTIONS = z.object({
         .describe("Base64-encoded JSON configuration for metadata transformers. Defines custom transformations applied to index mappings and settings during migration."),
     transformerConfig: z.string().optional()
         .describe("Inline JSON configuration for metadata transformers. Keys are transformer names and values are their configuration. Alternative to transformerConfigBase64 for simple configurations."),
-    transformerConfigFile: z.string().optional()
-        .describe("Path to a JSON file containing metadata transformer configuration. The file is read from the container filesystem."),
 }).describe("Process-level options for the metadata migration command, controlling which metadata is migrated and how it is transformed.");
 
 export const USER_METADATA_WORKFLOW_OPTION_KEYS = getZodKeys(USER_METADATA_WORKFLOW_OPTIONS);
@@ -413,8 +407,6 @@ export const USER_RFS_PROCESS_OPTIONS = z.object({
         .describe("Base64-encoded JSON configuration for document transformers. Defines custom transformations applied to each document during the backfill (e.g. field renaming, type conversion)."),
     docTransformerConfig: z.string().optional()
         .describe("Inline JSON configuration for document transformers. Keys are transformer names and values are their configuration. Alternative to docTransformerConfigBase64 for simple configurations."),
-    docTransformerConfigFile: z.string().optional()
-        .describe("Path to a JSON file containing document transformer configuration. The file is read from the container filesystem."),
     documentsPerBulkRequest: z.number().default(0x7fffffff).optional()
         .describe("Maximum number of documents per bulk indexing request to the target cluster. Lower values reduce per-request latency but increase overhead."),
     documentsSizePerBulkRequest: z.number().default(10*1024*1024).optional()

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -200,7 +200,7 @@ export const USER_PROXY_WORKFLOW_OPTIONS = z.object({
 
 export const USER_PROXY_PROCESS_OPTIONS = z.object({
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
-        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector. The proxy sends metrics and traces to this endpoint."),
+        .describe("URL for the OpenTelemetry Collector to which the proxy sends metrics and traces."),
     setHeader: z.array(z.string()).optional()
         .describe("List of static headers to add to proxied requests, each in 'Header-Name: value' format."),
     destinationConnectionPoolSize: z.number().default(0).optional()
@@ -268,7 +268,7 @@ export const USER_REPLAYER_PROCESS_OPTIONS = z.object({
     observedPacketConnectionTimeout: z.number().default(360).optional()
         .describe("Seconds of inactivity on a captured connection before assuming it was terminated in the original traffic stream."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
-        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector. The replayer sends metrics and traces to this endpoint for monitoring replay progress."),
+        .describe("URL for the OpenTelemetry Collector to which the replayer sends metrics and traces."),
     quiescentPeriodMs: z.number().default(5000).optional()
         .describe("Milliseconds to delay the first request on a resumed connection after a Kafka partition reassignment. Prevents request bursts during rebalancing."),
     removeAuthHeader: z.boolean().default(false).optional()
@@ -356,7 +356,7 @@ export const USER_METADATA_PROCESS_OPTIONS = z.object({
             "'UNION': merge all types into a single mapping. " +
             "'SPLIT': create separate indices for each type."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
-        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector for metadata migration metrics."),
+        .describe("URL for the OpenTelemetry Collector for metadata migration metrics."),
     output: z.union(["HUMAN_READABLE", "JSON"].map(s=>z.literal(s))).default("HUMAN_READABLE").optional()
         .describe("Output format for the metadata migration evaluation report. 'HUMAN_READABLE' for formatted text, 'JSON' for machine-parseable output."),
     transformerConfigBase64: z.string().default("").optional()
@@ -412,7 +412,7 @@ export const USER_RFS_PROCESS_OPTIONS = z.object({
     maxShardSizeBytes: z.number().default(80*1024*1024*1024).optional()
         .describe("Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
-        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."),
+        .describe("URL for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."),
 }).describe("Process-level options for the RFS document backfill command, controlling indexing behavior, concurrency, and transformations.");
 
 export const USER_RFS_WORKFLOW_OPTION_KEYS = getZodKeys(USER_RFS_WORKFLOW_OPTIONS);

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -94,14 +94,19 @@ function validateOptionalDefaultConsistency<T extends z.ZodTypeAny>(
 }
 
 export const S3_REPO_CONFIG = z.object({
-    awsRegion: z.string().describe("The AWS region that the bucket reside in (us-east-2, etc)"),
+    awsRegion: z.string()
+        .describe("AWS region where the S3 bucket resides (e.g. 'us-east-2'). Used for S3 client configuration and snapshot repository registration."),
     endpoint: z.string().regex(/(?:^(http|localstack)s?:\/\/[^/]*\/?$)?/).default("").optional()
-        .describe("Override the default S3 endpoint for clients to connect to. " +
-            "Necessary for testing, when S3 isn't used, or when it's only accessible via another endpoint"),
-    s3RepoPathUri: z.string().regex(/^s3:\/\/[a-z0-9][a-z0-9.-]{1,61}[a-z0-9](\/[a-zA-Z0-9!\-_.*'()/]*)?$/).describe("s3://BUCKETNAME/PATH"),
+        .describe("Override the default S3 endpoint URL. Supports http://, https://, localstack://, and localstacks:// schemes. " +
+            "LocalStack endpoints are automatically resolved to IP addresses during config transformation. " +
+            "Leave empty to use the default AWS S3 endpoint."),
+    s3RepoPathUri: z.string().regex(/^s3:\/\/[a-z0-9][a-z0-9.-]{1,61}[a-z0-9](\/[a-zA-Z0-9!\-_.*'()/]*)?$/)
+        .describe("S3 URI for the snapshot repository in the format 's3://BUCKET_NAME/OPTIONAL_PATH'. " +
+            "The bucket must already exist and be accessible from the source cluster."),
     s3RoleArn: z.string().regex(/^(arn:aws:iam::\d{12}:(user|role|group|policy)\/[a-zA-Z0-9+=,.@_-]+)?$/).default("").optional()
-        .describe("IAM role ARN to assume when accessing S3 for snapshot operations")
-});
+        .describe("IAM role ARN to assume when accessing S3 for snapshot operations. " +
+            "Leave empty to use the default credentials of the migration infrastructure.")
+}).describe("Configuration for an S3-backed snapshot repository used by the source cluster.");
 
 export const PORT_NUMBER_PATTERN = "(?:[1-9]\\d{0,3}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])";
 export const OPTIONAL_PORT_PATTERN = `(?::${PORT_NUMBER_PATTERN})?`;
@@ -110,102 +115,125 @@ export const HTTP_ENDPOINT_PATTERN = `^https?:\\/\\/${HOSTNAME_PATTERN}${OPTIONA
 export const OPTIONAL_HTTP_ENDPOINT_PATTERN = `^(?:https?:\\/\\/${HOSTNAME_PATTERN}${OPTIONAL_PORT_PATTERN}(?:\\/)?)?$`;
 
 export const KAFKA_CLIENT_CONFIG = z.object({
-    enableMSKAuth: z.boolean().default(false).optional(),
+    enableMSKAuth: z.boolean().default(false).optional()
+        .describe("Enable SASL/IAM authentication for Amazon MSK. When true, configures the Kafka client with the required SASL properties for IAM-based authentication."),
     kafkaConnection: z.string()
-        .describe("Sequence of <HOSTNAME:PORT> values delimited by ','.  " +
-            "If empty, the cluster is automatically created and this is filled in.")
+        .describe("Comma-delimited list of Kafka broker addresses in 'HOSTNAME:PORT' format (e.g. 'broker1:9092,broker2:9092'). " +
+            "If empty, a Kafka cluster is automatically created and this value is populated.")
         .regex(new RegExp(`^(?:[a-z0-9][-a-z0-9.]*:${PORT_NUMBER_PATTERN}(?:,(?!$)|$))*$`)),
-    kafkaTopic: z.string().describe("Empty defaults to the name of the target label").default(""),
-});
+    kafkaTopic: z.string()
+        .describe("Kafka topic name for captured traffic. If empty, defaults to the name of the associated proxy or target label.")
+        .default(""),
+}).describe("Client connection configuration for an existing Kafka cluster.");
 
 export const K8S_NAMING_PATTERN = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 
 export const CPU_QUANTITY = z.string()
     .regex(/^[0-9]+m$/)
-    .describe("CPU quantity in millicores (e.g., '100m', '500m')");
+    .describe("CPU quantity in Kubernetes millicores (e.g. '100m' = 0.1 CPU, '3500m' = 3.5 CPUs). Must end with 'm'.");
 
 export const MEMORY_QUANTITY = z.string()
     .regex(/^[0-9]+(([EPTGM])i?|Ki|k)$/)
-    .describe("Memory quantity with unit (e.g., '512Mi', '2G')");
+    .describe("Memory quantity in Kubernetes resource format with binary or decimal units (e.g. '512Mi', '2Gi', '4G').");
 
 export const STORAGE_QUANTITY = z.string()
     .regex(/^[0-9]+(([EPTGM])i?|Ki|k)$/)
-    .describe("Storage quantity with unit (e.g., '10Gi', '5G')");
+    .describe("Storage quantity in Kubernetes resource format with binary or decimal units (e.g. '10Gi', '100G').");
 
 export const CONTAINER_RESOURCES = {
-    cpu: CPU_QUANTITY,
-    memory: MEMORY_QUANTITY,
+    cpu: CPU_QUANTITY.describe("CPU allocation for the container in Kubernetes millicores."),
+    memory: MEMORY_QUANTITY.describe("Memory allocation for the container."),
     "ephemeral-storage": STORAGE_QUANTITY.optional()
+        .describe("Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration.")
 }
 
 export const RESOURCE_REQUIREMENTS = z.object({
-    limits: z.object(CONTAINER_RESOURCES).describe("Resource upper bound for a container"),
-    requests: z.object(CONTAINER_RESOURCES).describe("Resource lower bound for a container")
-}).describe("Compute resource requirements for a container." +
-    "There are implications to how a task will be evicted if the resources and limits are different.  " +
-    "See https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#guaranteed for more information.");
+    limits: z.object(CONTAINER_RESOURCES).describe("Maximum resource limits for the container. The container will be terminated if it exceeds these limits."),
+    requests: z.object(CONTAINER_RESOURCES).describe("Minimum guaranteed resources for the container. Used by the Kubernetes scheduler for pod placement.")
+}).describe("Kubernetes compute resource requirements for a container. " +
+    "When limits equal requests, the pod gets 'Guaranteed' QoS class and is less likely to be evicted. " +
+    "See https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#guaranteed for details.");
 
 export type ResourceRequirementsType = z.infer<typeof RESOURCE_REQUIREMENTS>;
 
 export const CERT_MANAGER_ISSUER_REF = z.object({
-    name: z.string().describe("Name of the cert-manager Issuer or ClusterIssuer."),
+    name: z.string().describe("Name of the cert-manager Issuer or ClusterIssuer resource that will sign the certificate."),
     kind: z.enum(["Issuer", "ClusterIssuer"]).default("ClusterIssuer").optional()
-        .describe("Kind of the issuer resource."),
+        .describe("Kind of the cert-manager issuer resource. 'ClusterIssuer' is cluster-scoped; 'Issuer' is namespace-scoped."),
     group: z.string().default("cert-manager.io").optional()
-        .describe("API group of the issuer. Use 'awspca.cert-manager.io' for AWS PCA issuers."),
-});
+        .describe("API group of the issuer. Use 'cert-manager.io' for standard issuers or 'awspca.cert-manager.io' for AWS Private CA issuers."),
+}).describe("Reference to a cert-manager issuer that will sign TLS certificates for the proxy.");
 
 export const PROXY_TLS_CONFIG = z.discriminatedUnion("mode", [
     z.object({
-        mode: z.literal("certManager"),
+        mode: z.literal("certManager")
+            .describe("Use cert-manager to automatically provision and renew a TLS certificate."),
         issuerRef: CERT_MANAGER_ISSUER_REF,
-        commonName: z.string().optional(),
+        commonName: z.string().optional()
+            .describe("Optional common name (CN) for the TLS certificate subject."),
         dnsNames: z.array(z.string()).min(1)
-            .describe("DNS names for the certificate. Must include the proxy's service DNS name."),
+            .describe("DNS Subject Alternative Names for the certificate. Must include the proxy's Kubernetes service DNS name (e.g. 'my-proxy.default.svc.cluster.local')."),
         duration: z.string().default("2160h").optional()
-            .describe("Requested certificate validity duration (default: 90 days)."),
+            .describe("Requested certificate validity duration in Go duration format. Default is '2160h' (90 days)."),
         renewBefore: z.string().default("360h").optional()
-            .describe("How long before expiry to renew (default: 15 days)."),
-    }).describe("Use cert-manager to provision a TLS certificate for the proxy."),
+            .describe("How long before certificate expiry to trigger renewal. Default is '360h' (15 days)."),
+    }).describe("Provision a TLS certificate via cert-manager. A Certificate resource is created and the resulting secret is mounted into the proxy pod."),
     z.object({
-        mode: z.literal("existingSecret"),
+        mode: z.literal("existingSecret")
+            .describe("Use a pre-existing Kubernetes TLS secret."),
         secretName: z.string()
-            .describe("Name of an existing K8s TLS secret with tls.crt and tls.key."),
-    }).describe("Use a pre-existing K8s TLS secret."),
-]);
+            .describe("Name of an existing Kubernetes TLS secret containing 'tls.crt' and 'tls.key' entries. The secret is mounted into the proxy pod at /etc/proxy-tls/."),
+    }).describe("Use a pre-existing Kubernetes TLS secret for proxy HTTPS termination."),
+]).describe("TLS configuration for the capture proxy. Determines how the proxy obtains its TLS certificate for HTTPS termination.");
 
 export const USER_PROXY_WORKFLOW_OPTIONS = z.object({
-    loggingConfigurationOverrideConfigMap: z.string().default("").optional(),
+    loggingConfigurationOverrideConfigMap: z.string().default("").optional()
+        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration. When set, the ConfigMap is mounted into the container and used to override default logging. Leave empty to use built-in logging defaults."),
     internetFacing: z.boolean().default(false).optional()
-        .describe("When true, configures the proxy Service load balancer scheme as internet-facing."),
-    podReplicas: z.number().default(1).optional(),
+        .describe("When true, the proxy's Kubernetes Service is annotated with 'internet-facing' load balancer scheme, making it accessible from outside the VPC. When false (default), the load balancer is internal-only."),
+    podReplicas: z.number().default(1).optional()
+        .describe("Number of proxy pod replicas in the Kubernetes Deployment. Increase for higher throughput or availability."),
     resources: z.preprocess((v) => deepmerge(DEFAULT_RESOURCES.PROXY, (v ?? {})), RESOURCE_REQUIREMENTS)
-        .describe("Resource limits and requests for proxy container.")
+        .describe("Kubernetes resource limits and requests for the capture proxy container. Defaults to 3500m CPU and 3500Mi memory for both limits and requests (Guaranteed QoS).")
         .default(DEFAULT_RESOURCES.PROXY),
-});
+}).describe("Kubernetes deployment-level options for the capture proxy.");
 
 export const USER_PROXY_PROCESS_OPTIONS = z.object({
-    otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional(),
-    setHeader: z.array(z.string()).optional(),
-    destinationConnectionPoolSize: z.number().default(0).optional(),
+    otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
+        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector. The proxy sends metrics and traces to this endpoint. Default points to the in-cluster collector service."),
+    setHeader: z.array(z.string()).optional()
+        .describe("List of static headers to add to proxied requests, each in 'Header-Name: value' format."),
+    destinationConnectionPoolSize: z.number().default(0).optional()
+        .describe("Maximum number of persistent connections to the destination (source) cluster. 0 means unlimited/default connection pooling."),
     destinationConnectionPoolTimeout: z.string()
         .regex(/^[-+]?P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/)
-        .default("PT30S").optional(),
-    kafkaClientId: z.string().default("HttpCaptureProxyProducer").optional(),
-    listenPort: z.number(),
-    maxTrafficBufferSize: z.number().default(1048576).optional(),
-    noCapture: z.boolean().default(false).optional(),
-    numThreads: z.number().default(1).optional(),
+        .default("PT30S").optional()
+        .describe("ISO 8601 duration for how long idle connections in the destination pool are kept alive before being closed (e.g. 'PT30S' = 30 seconds, 'PT5M' = 5 minutes)."),
+    kafkaClientId: z.string().default("HttpCaptureProxyProducer").optional()
+        .describe("Kafka producer client ID used when publishing captured traffic to Kafka. Useful for identifying this proxy in Kafka broker logs and metrics."),
+    listenPort: z.number()
+        .describe("TCP port the capture proxy listens on for incoming HTTP(S) traffic. This port is exposed via the Kubernetes Service and used to construct the proxy endpoint URL."),
+    maxTrafficBufferSize: z.number().default(1048576).optional()
+        .describe("Maximum size in bytes for buffering a single HTTP request/response payload before forwarding to Kafka. Default is 1048576 (1 MiB)."),
+    noCapture: z.boolean().default(false).optional()
+        .describe("When true, the proxy forwards traffic to the source cluster without capturing it to Kafka. Useful for TLS termination or routing without traffic recording."),
+    numThreads: z.number().default(1).optional()
+        .describe("Number of Netty worker threads for the proxy to handle concurrent connections."),
     sslConfigFile: z.string().optional()
-        .describe("Legacy: YAML config for OpenSearch security SSL. Prefer tls config for K8s deployments."),
+        .describe("Path to a YAML file with OpenSearch security SSL configuration (plugins.security.ssl.http.* keys). Legacy option for non-Kubernetes deployments. For Kubernetes, prefer the 'tls' configuration instead."),
     tls: PROXY_TLS_CONFIG.optional()
-        .describe("TLS certificate configuration for the proxy. Mutually exclusive with sslConfigFile."),
-    enableMSKAuth: z.boolean().default(false).optional(),
-    suppressCaptureForHeaderMatch: z.array(z.string()).default([]).optional(),
-    suppressCaptureForMethod: z.string().default("").optional(),
-    suppressCaptureForUriPath: z.string().default("").optional(),
-    suppressMethodAndPath: z.string().default("").optional(),
-});
+        .describe("TLS certificate configuration for HTTPS termination at the proxy. When configured, the proxy serves HTTPS and the TLS secret is mounted at /etc/proxy-tls/. Mutually exclusive with sslConfigFile."),
+    enableMSKAuth: z.boolean().default(false).optional()
+        .describe("Enable SASL/IAM authentication for the proxy's Kafka producer when connecting to Amazon MSK."),
+    suppressCaptureForHeaderMatch: z.array(z.string()).default([]).optional()
+        .describe("List of header patterns. Requests matching any of these header patterns will be forwarded but not captured to Kafka."),
+    suppressCaptureForMethod: z.string().default("").optional()
+        .describe("HTTP method to suppress from capture (e.g. 'HEAD'). Requests with this method are forwarded but not recorded."),
+    suppressCaptureForUriPath: z.string().default("").optional()
+        .describe("URI path pattern to suppress from capture. Requests matching this path are forwarded but not recorded."),
+    suppressMethodAndPath: z.string().default("").optional()
+        .describe("Combined method and path pattern for capture suppression in 'METHOD /path' format."),
+}).describe("Process-level configuration options for the capture proxy application. These are passed as command-line arguments to the proxy container.");
 
 export const USER_PROXY_WORKFLOW_OPTION_KEYS = getZodKeys(USER_PROXY_WORKFLOW_OPTIONS);
 export const USER_PROXY_PROCESS_OPTION_KEYS = getZodKeys(USER_PROXY_PROCESS_OPTIONS);
@@ -216,51 +244,54 @@ export const USER_PROXY_OPTIONS = z.object({
 });
 
 export const USER_REPLAYER_WORKFLOW_OPTIONS = z.object({
-    jvmArgs: z.string().default("").optional(),
-    loggingConfigurationOverrideConfigMap: z.string().default("").optional(),
-    podReplicas: z.number().default(1).optional(),
+    jvmArgs: z.string().default("").optional()
+        .describe("Additional JVM arguments passed to the replayer process via JDK_JAVA_OPTIONS (e.g. '-Xmx4g -XX:+UseG1GC'). Leave empty for JVM defaults."),
+    loggingConfigurationOverrideConfigMap: z.string().default("").optional()
+        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the replayer. Leave empty to use built-in logging defaults."),
+    podReplicas: z.number().default(1).optional()
+        .describe("Number of replayer pod replicas in the Kubernetes Deployment. Each replica independently consumes from Kafka and replays traffic to the target."),
     resources: z.preprocess((v) => deepmerge(DEFAULT_RESOURCES.REPLAYER, (v ?? {})), RESOURCE_REQUIREMENTS)
-        .describe("Resource limits and requests for replayer container."),
-});
+        .describe("Kubernetes resource limits and requests for the replayer container. Defaults to 3500m CPU and 3500Mi memory (Guaranteed QoS)."),
+}).describe("Kubernetes deployment-level options for the traffic replayer.");
 
 export const USER_REPLAYER_PROCESS_OPTIONS = z.object({
     kafkaTrafficEnableMSKAuth: z.boolean().default(false).optional()
-        .describe("Enables SASL properties required for connecting to MSK with IAM auth."),
+        .describe("Enable SASL/IAM authentication for the replayer's Kafka consumer when connecting to Amazon MSK."),
     kafkaTrafficPropertyFile: z.string().optional()
-        .describe("File path for Kafka properties file for additional or overridden Kafka properties."),
+        .describe("Path to a Java properties file with additional or overridden Kafka consumer configuration. Mounted into the replayer container."),
     lookaheadTimeSeconds: z.number().default(400).optional()
-        .describe("Number of seconds of data that will be buffered."),
+        .describe("Number of seconds of captured traffic to buffer ahead of the current replay position. Larger values improve throughput but increase memory usage."),
     maxConcurrentRequests: z.number().default(10000).optional()
-        .describe("Maximum number of requests that can be outstanding at a time."),
+        .describe("Maximum number of HTTP requests that can be in-flight simultaneously to the target cluster. Limits concurrency to prevent overwhelming the target."),
     numClientThreads: z.number().default(0).optional()
-        .describe("Number of threads to use to send requests from."),
+        .describe("Number of threads used to send replayed requests to the target. 0 uses the Netty default (typically number of available processors)."),
     observedPacketConnectionTimeout: z.number().default(360).optional()
-        .describe("Seconds of inactivity before assuming connections were terminated in the captured stream."),
+        .describe("Seconds of inactivity on a captured connection before assuming it was terminated in the original traffic stream."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
-        .describe("Endpoint (host:port) for the OpenTelemetry Collector for metrics forwarding."),
+        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector. The replayer sends metrics and traces to this endpoint for monitoring replay progress."),
     quiescentPeriodMs: z.number().default(5000).optional()
-        .describe("Milliseconds to delay the first request on a resumed connection after Kafka partition reassignment."),
+        .describe("Milliseconds to delay the first request on a resumed connection after a Kafka partition reassignment. Prevents request bursts during rebalancing."),
     removeAuthHeader: z.boolean().default(false).optional()
-        .describe("Remove the authorization header if present without replacing it."),
+        .describe("Remove the Authorization header from replayed requests without replacing it. Useful when the target uses a different auth mechanism (e.g. SigV4) configured separately."),
     speedupFactor: z.number().default(1.1).optional()
-        .describe("Factor to accelerate replayed communications relative to original timing."),
+        .describe("Multiplier to accelerate replay timing relative to the original captured traffic. 1.0 = real-time, 2.0 = double speed. Default 1.1 provides a slight speedup to keep replay ahead of capture."),
     targetServerResponseTimeoutSeconds: z.number().default(150).optional()
-        .describe("Seconds to wait before timing out a replayed request to the target."),
+        .describe("Maximum seconds to wait for a response from the target cluster before timing out a replayed request."),
     transformerConfig: z.string().optional()
-        .describe("Request transformer configuration as a string or JSON."),
+        .describe("Inline request transformer configuration as a JSON string. Defines transformations applied to each request before replaying to the target."),
     transformerConfigEncoded: z.string().optional()
-        .describe("Base64-encoded request transformer configuration."),
+        .describe("Base64-encoded request transformer configuration. Alternative to transformerConfig for configurations containing special characters."),
     transformerConfigFile: z.string().optional()
-        .describe("Path to the JSON configuration file for request transformers."),
+        .describe("Path to a JSON file containing request transformer configuration. The file is read from the container filesystem."),
     tupleTransformerConfig: z.string().optional()
-        .describe("Tuple transformer configuration as a string or JSON."),
+        .describe("Inline tuple transformer configuration as a JSON string. Tuple transformers operate on request-response pairs for stateful transformations."),
     tupleTransformerConfigBase64: z.string().optional()
         .describe("Base64-encoded tuple transformer configuration."),
     tupleTransformerConfigFile: z.string().optional()
-        .describe("Path to the JSON configuration file for tuple transformers."),
+        .describe("Path to a JSON file containing tuple transformer configuration."),
     userAgent: z.string().optional()
-        .describe("String appended to the user-agent header for requests to the target cluster."),
-});
+        .describe("String appended to the User-Agent header on all replayed requests to the target cluster. Useful for identifying replayed traffic in target cluster logs."),
+}).describe("Process-level configuration options for the traffic replayer application. These control how captured traffic is consumed from Kafka and replayed to the target cluster.");
 
 export const USER_REPLAYER_WORKFLOW_OPTION_KEYS = getZodKeys(USER_REPLAYER_WORKFLOW_OPTIONS);
 export const USER_REPLAYER_PROCESS_OPTION_KEYS = getZodKeys(USER_REPLAYER_PROCESS_OPTIONS);
@@ -273,15 +304,20 @@ export const USER_REPLAYER_OPTIONS = z.object({
 // Note: noWait is not included here as it is hardcoded to true in the workflow.
 // The workflow manages snapshot completion polling separately via checkSnapshotStatus.
 export const USER_CREATE_SNAPSHOT_WORKFLOW_OPTIONS = z.object({
-    snapshotPrefix: z.string().default("").optional(),
-    jvmArgs: z.string().default("").optional(),
+    snapshotPrefix: z.string().default("").optional()
+        .describe("Prefix for auto-generated snapshot names. The final snapshot name is constructed as '<sourceLabel>_<snapshotPrefix>_<uniqueRunNonce>'. If empty, the snapshot record key name is used as the prefix."),
+    jvmArgs: z.string().default("").optional()
+        .describe("Additional JVM arguments passed to the CreateSnapshot process via JDK_JAVA_OPTIONS (e.g. '-Xmx2g')."),
     loggingConfigurationOverrideConfigMap: z.string().default("").optional()
-});
+        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the snapshot creation process. Leave empty for defaults.")
+}).describe("Workflow-level options for snapshot creation, controlling naming and JVM configuration.");
 
 export const USER_CREATE_SNAPSHOT_PROCESS_OPTIONS = z.object({
-    indexAllowlist: z.array(z.string()).default([]).optional(),
-    maxSnapshotRateMbPerNode: z.number().default(0).optional(),
-});
+    indexAllowlist: z.array(z.string()).default([]).optional()
+        .describe("List of index name patterns to include in the snapshot. An empty list means all indices are included."),
+    maxSnapshotRateMbPerNode: z.number().default(0).optional()
+        .describe("Maximum snapshot throughput in MB/s per data node. 0 means no rate limiting. Use to reduce I/O impact on the source cluster during snapshot creation."),
+}).describe("Process-level options for the CreateSnapshot command, controlling which indices are snapshotted and rate limiting.");
 
 export const USER_CREATE_SNAPSHOT_WORKFLOW_OPTION_KEYS = getZodKeys(USER_CREATE_SNAPSHOT_WORKFLOW_OPTIONS);
 export const USER_CREATE_SNAPSHOT_PROCESS_OPTION_KEYS = getZodKeys(USER_CREATE_SNAPSHOT_PROCESS_OPTIONS);
@@ -292,24 +328,40 @@ export const USER_CREATE_SNAPSHOT_OPTIONS = z.object({
 });
 
 export const USER_METADATA_WORKFLOW_OPTIONS = z.object({
-    jvmArgs: z.string().default("").optional(),
-    loggingConfigurationOverrideConfigMap: z.string().default("").optional(),
-    skipEvaluateApproval: z.boolean().default(false).optional(), // TODO - fullmigration
-    skipMigrateApproval: z.boolean().default(false).optional() // TODO - fullmigration
-});
+    jvmArgs: z.string().default("").optional()
+        .describe("Additional JVM arguments passed to the metadata migration process via JDK_JAVA_OPTIONS."),
+    loggingConfigurationOverrideConfigMap: z.string().default("").optional()
+        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the metadata migration process."),
+    skipEvaluateApproval: z.boolean().default(false).optional()
+        .describe("When true, skips the manual approval gate before the metadata evaluation step. The evaluation step analyzes what metadata changes would be applied without making changes."),
+    skipMigrateApproval: z.boolean().default(false).optional()
+        .describe("When true, skips the manual approval gate before the metadata migration step. The migration step applies the evaluated metadata changes to the target cluster.")
+}).describe("Workflow-level options for metadata migration, controlling JVM settings and approval gates.");
 
 export const USER_METADATA_PROCESS_OPTIONS = z.object({
-    componentTemplateAllowlist: z.array(z.string()).default([]).optional(),
-    indexAllowlist: z.array(z.string()).default([]).optional(),
-    indexTemplateAllowlist: z.array(z.string()).default([]).optional(),
+    componentTemplateAllowlist: z.array(z.string()).default([]).optional()
+        .describe("List of component template name patterns to include in the metadata migration. An empty list means all component templates are included."),
+    indexAllowlist: z.array(z.string()).default([]).optional()
+        .describe("List of index name patterns to include in the metadata migration. An empty list means all indices are included."),
+    indexTemplateAllowlist: z.array(z.string()).default([]).optional()
+        .describe("List of index template name patterns to include in the metadata migration. An empty list means all index templates are included."),
 
-    allowLooseVersionMatching: z.boolean().default(true).optional(),
-    clusterAwarenessAttributes: z.number().default(1).optional(),
-    multiTypeBehavior: z.union(["NONE", "UNION", "SPLIT"].map(s=>z.literal(s))).default("NONE").optional(),
-    otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional(),
-    output: z.union(["HUMAN_READABLE", "JSON"].map(s=>z.literal(s))).default("HUMAN_READABLE").optional(),
-    transformerConfigBase64: z.string().default("").optional(),
-});
+    allowLooseVersionMatching: z.boolean().default(true).optional()
+        .describe("When true, allows metadata migration between clusters with non-exact version compatibility (e.g. ES 7.x to OS 2.x). When false, requires strict version matching."),
+    clusterAwarenessAttributes: z.number().default(1).optional()
+        .describe("Number of shard allocation awareness attributes to preserve during metadata migration. Controls how index settings related to cluster topology are handled."),
+    multiTypeBehavior: z.union(["NONE", "UNION", "SPLIT"].map(s=>z.literal(s))).default("NONE").optional()
+        .describe("Strategy for handling Elasticsearch multi-type indices (ES 5.x and earlier). " +
+            "'NONE': fail if multi-type indices are encountered. " +
+            "'UNION': merge all types into a single mapping. " +
+            "'SPLIT': create separate indices for each type."),
+    otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
+        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector for metadata migration metrics."),
+    output: z.union(["HUMAN_READABLE", "JSON"].map(s=>z.literal(s))).default("HUMAN_READABLE").optional()
+        .describe("Output format for the metadata migration evaluation report. 'HUMAN_READABLE' for formatted text, 'JSON' for machine-parseable output."),
+    transformerConfigBase64: z.string().default("").optional()
+        .describe("Base64-encoded JSON configuration for metadata transformers. Defines custom transformations applied to index mappings and settings during migration."),
+}).describe("Process-level options for the metadata migration command, controlling which metadata is migrated and how it is transformed.");
 
 export const USER_METADATA_WORKFLOW_OPTION_KEYS = getZodKeys(USER_METADATA_WORKFLOW_OPTIONS);
 export const USER_METADATA_PROCESS_OPTION_KEYS = getZodKeys(USER_METADATA_PROCESS_OPTIONS);
@@ -320,34 +372,48 @@ export const USER_METADATA_OPTIONS = z.object({
 });
 
 export const USER_RFS_WORKFLOW_OPTIONS = z.object({
-    podReplicas: z.number().default(1).optional(),
-    jvmArgs: z.string().default("").optional(),
-    loggingConfigurationOverrideConfigMap: z.string().default("").optional(),
-    skipApproval: z.boolean().default(false).optional(),  // TODO - fullmigration
+    podReplicas: z.number().default(1).optional()
+        .describe("Number of RFS (Reindex From Snapshot) pod replicas in the Kubernetes Deployment. Each replica processes shards independently using distributed work coordination."),
+    jvmArgs: z.string().default("").optional()
+        .describe("Additional JVM arguments passed to the RFS process via JDK_JAVA_OPTIONS (e.g. '-Xmx6g'). Tune based on shard sizes and available memory."),
+    loggingConfigurationOverrideConfigMap: z.string().default("").optional()
+        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the RFS process."),
+    skipApproval: z.boolean().default(false).optional()
+        .describe("When true, skips the manual approval gate before starting the document backfill. Useful for automated pipelines where human approval is not needed."),
     useTargetClusterForWorkCoordination: z.boolean().default(false)
-        .describe("When true, uses the target OpenSearch cluster for RFS work coordination. When false, a dedicated single-node OpenSearch coordinator cluster is deployed and managed for the lifetime of the migration, then torn down on completion."),
+        .describe("When true, uses the target OpenSearch cluster for RFS work coordination (lease management and shard assignment). " +
+            "When false (default), a dedicated single-node OpenSearch coordinator cluster is automatically deployed, used for the lifetime of the migration, then torn down on completion. " +
+            "Using a dedicated coordinator avoids adding coordination overhead to the target cluster."),
     resources: z.preprocess((v) => deepmerge(DEFAULT_RESOURCES.RFS, (v ?? {})), RESOURCE_REQUIREMENTS)
         .pipe(RESOURCE_REQUIREMENTS.extend({
             requests: RESOURCE_REQUIREMENTS.shape.requests.extend({
                 "ephemeral-storage":
                     RESOURCE_REQUIREMENTS.shape.requests.shape["ephemeral-storage"].describe(
-                        "If omitted, automatically computed during transform as ceil(2.5 * maxShardSizeBytes)."
+                        "Ephemeral storage for RFS temporary Lucene segments. If omitted, automatically computed as ceil(2.5 * maxShardSizeBytes) to ensure sufficient space for the largest shard."
                     ),
             }),
         }))
-        .describe("Resource limits and requests for RFS container"),
-});
+        .describe("Kubernetes resource limits and requests for the RFS container. Defaults to 3300m CPU and 7000Mi memory. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."),
+}).describe("Kubernetes deployment-level options for the Reindex From Snapshot (RFS) document backfill.");
 
 export const USER_RFS_PROCESS_OPTIONS = z.object({
-    indexAllowlist: z.array(z.string()).default([]).optional(),
-    allowLooseVersionMatching: z.boolean().default(true).describe("").optional(),
-    docTransformerConfigBase64: z.string().default("").optional(),
-    documentsPerBulkRequest: z.number().default(0x7fffffff).optional(),
-    initialLeaseDuration: z.string().default("PT1H").optional(),
-    maxConnections: z.number().default(10).optional(),
-    maxShardSizeBytes: z.number().default(80*1024*1024*1024).optional(),
-    otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional(),
-});
+    indexAllowlist: z.array(z.string()).default([]).optional()
+        .describe("List of index name patterns to include in the document backfill. An empty list means all indices from the snapshot are migrated."),
+    allowLooseVersionMatching: z.boolean().default(true).optional()
+        .describe("When true, allows document migration between clusters with non-exact version compatibility."),
+    docTransformerConfigBase64: z.string().default("").optional()
+        .describe("Base64-encoded JSON configuration for document transformers. Defines custom transformations applied to each document during the backfill (e.g. field renaming, type conversion)."),
+    documentsPerBulkRequest: z.number().default(0x7fffffff).optional()
+        .describe("Maximum number of documents per bulk indexing request to the target cluster. Default is 2147483647 (effectively unlimited, bounded by request size). Lower values reduce per-request latency but increase overhead."),
+    initialLeaseDuration: z.string().default("PT1H").optional()
+        .describe("ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up."),
+    maxConnections: z.number().default(10).optional()
+        .describe("Maximum number of concurrent HTTP connections from each RFS worker to the target cluster for bulk indexing."),
+    maxShardSizeBytes: z.number().default(80*1024*1024*1024).optional()
+        .describe("Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Default is 85899345920 (80 GiB). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."),
+    otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
+        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."),
+}).describe("Process-level options for the RFS document backfill command, controlling indexing behavior, concurrency, and transformations.");
 
 export const USER_RFS_WORKFLOW_OPTION_KEYS = getZodKeys(USER_RFS_WORKFLOW_OPTIONS);
 export const USER_RFS_PROCESS_OPTION_KEYS = getZodKeys(USER_RFS_PROCESS_OPTIONS);
@@ -396,81 +462,113 @@ export const USER_RFS_OPTIONS = z.object({
 });
 
 export const KAFKA_CLUSTER_CREATION_CONFIG = z.object({
-    replicas:      z.number().int().min(1).default(1).optional(),
+    replicas:      z.number().int().min(1).default(1).optional()
+        .describe("Number of Kafka broker replicas in the Strimzi Kafka cluster. Increase for higher availability and throughput."),
     storage:       z.discriminatedUnion("type", [
-                       z.object({ type: z.literal("ephemeral") }),
-                       z.object({ type: z.literal("persistent-claim"), size: z.string() })
-                   ]).default({ type: "ephemeral" }).optional(),
-    partitions:    z.number().int().min(1).default(1).optional(),
-    topicReplicas: z.number().int().min(1).default(1).optional(),
-});
+                       z.object({ type: z.literal("ephemeral") })
+                           .describe("Use ephemeral (emptyDir) storage. Data is lost when pods restart. Suitable for development and testing."),
+                       z.object({ type: z.literal("persistent-claim"), size: z.string()
+                           .describe("Size of the PersistentVolumeClaim (e.g. '10Gi', '100Gi').") })
+                           .describe("Use persistent storage backed by a PersistentVolumeClaim. Required for production workloads.")
+                   ]).default({ type: "ephemeral" }).optional()
+                   .describe("Storage configuration for Kafka broker data."),
+    partitions:    z.number().int().min(1).default(1).optional()
+        .describe("Default number of partitions for auto-created Kafka topics. More partitions enable higher parallelism for consumers."),
+    topicReplicas: z.number().int().min(1).default(1).optional()
+        .describe("Replication factor for auto-created Kafka topics. Must not exceed the number of broker replicas. Higher values improve durability."),
+}).describe("Configuration for auto-creating a Strimzi Kafka cluster. Used when no existing Kafka cluster is provided.");
 
 export const KAFKA_CLUSTER_CONFIG = z.union([
-    z.object({autoCreate: KAFKA_CLUSTER_CREATION_CONFIG}),
+    z.object({autoCreate: KAFKA_CLUSTER_CREATION_CONFIG})
+        .describe("Auto-create a new Strimzi Kafka cluster with the specified configuration. The cluster bootstrap service is available at '<clusterName>-kafka-bootstrap:9092'."),
     z.object({existing: KAFKA_CLIENT_CONFIG })
-]);
+        .describe("Use an existing Kafka cluster by providing connection details.")
+]).describe("Kafka cluster configuration: either auto-create a new Strimzi cluster or connect to an existing one.");
 
 export const HTTP_AUTH_BASIC = z.object({
     basic: z.object({
         secretName: z.string().regex(K8S_NAMING_PATTERN)
+            .describe("Name of a Kubernetes Secret containing 'username' and 'password' keys for HTTP Basic authentication.")
     })
-});
+}).describe("HTTP Basic authentication using credentials from a Kubernetes Secret.");
 
 export const HTTP_AUTH_SIGV4 = z.object({
     sigv4: z.object({
-        region: z.string(),
-        service: z.string().default("es").optional(),
+        region: z.string()
+            .describe("AWS region for SigV4 request signing (e.g. 'us-east-1')."),
+        service: z.string().default("es").optional()
+            .describe("AWS service name for SigV4 signing. Use 'es' for Amazon OpenSearch Service or 'aoss' for OpenSearch Serverless."),
     })
-});
+}).describe("AWS SigV4 request signing authentication. Uses the pod's IAM role credentials.");
 
 export const HTTP_AUTH_MTLS = z.object({
     mtls: z.object({
-        caCert: z.string(),
+        caCert: z.string()
+            .describe("PEM-encoded CA certificate or path to CA certificate file for verifying the server's TLS certificate."),
         clientSecretName: z.string()
+            .describe("Name of a Kubernetes TLS Secret containing the client certificate and private key for mutual TLS authentication.")
     })
-});
+}).describe("Mutual TLS (mTLS) authentication using client certificates.");
 
-export const CLUSTER_VERSION_STRING = z.string().regex(/^(?:ES [125678]|OS [123])(?:\.[0-9]+)+$/);
+export const CLUSTER_VERSION_STRING = z.string().regex(/^(?:ES [125678]|OS [123])(?:\.[0-9]+)+$/)
+    .describe("Cluster version string in '<ENGINE> <VERSION>' format. Supported engines: 'ES' (Elasticsearch) versions 1, 2, 5, 6, 7, 8; 'OS' (OpenSearch) versions 1, 2, 3. Examples: 'ES 7.10.2', 'OS 2.11.0'.");
 
 export const CLUSTER_CONFIG = z.object({
-    endpoint:  z.string().regex(new RegExp(OPTIONAL_HTTP_ENDPOINT_PATTERN)).default("").optional(),
-    allowInsecure: z.boolean().default(false).optional(),
-    authConfig: z.union([HTTP_AUTH_BASIC, HTTP_AUTH_SIGV4, HTTP_AUTH_MTLS]).optional(),
-});
+    endpoint:  z.string().regex(new RegExp(OPTIONAL_HTTP_ENDPOINT_PATTERN)).default("").optional()
+        .describe("HTTP(S) endpoint URL for the cluster (e.g. 'https://my-cluster:9200/'). Leave empty if the cluster is not directly accessible or will be accessed through a proxy."),
+    allowInsecure: z.boolean().default(false).optional()
+        .describe("When true, disables TLS certificate verification when connecting to the cluster. Use only for development or self-signed certificates."),
+    authConfig: z.union([HTTP_AUTH_BASIC, HTTP_AUTH_SIGV4, HTTP_AUTH_MTLS]).optional()
+        .describe("Authentication configuration for connecting to the cluster. Supports HTTP Basic (Kubernetes Secret), AWS SigV4, or mutual TLS."),
+}).describe("Base connection configuration for an Elasticsearch or OpenSearch cluster.");
 
 export const TARGET_CLUSTER_CONFIG = CLUSTER_CONFIG.extend({
-    enabled: z.boolean().default(true).optional(),
-    endpoint:  z.string().regex(new RegExp(HTTP_ENDPOINT_PATTERN)), // override to required
-});
+    enabled: z.boolean().default(true).optional()
+        .describe("When false, this target cluster is excluded from the migration. Useful for temporarily disabling a target without removing its configuration."),
+    endpoint:  z.string().regex(new RegExp(HTTP_ENDPOINT_PATTERN))
+        .describe("HTTP(S) endpoint URL for the target cluster (e.g. 'https://target-cluster:9200/'). Required for target clusters."),
+}).describe("Connection configuration for a target OpenSearch cluster. Extends the base cluster config with a required endpoint.");
 
 export const SOURCE_CLUSTER_REPOS_RECORD =
     z.record(z.string(), S3_REPO_CONFIG)
-    .describe("Keys are the repository names that are managed by the source cluster");
+    .describe("Map of snapshot repository names to their S3 configurations. Keys are the repository names as registered in the source cluster.");
 
 export const CAPTURE_CONFIG = z.object({
-    kafka: z.string().regex(K8S_NAMING_PATTERN).default("default").optional(),
+    kafka: z.string().regex(K8S_NAMING_PATTERN).default("default").optional()
+        .describe("Name of the Kafka cluster to use for captured traffic. Must match a key in kafkaClusterConfiguration. Defaults to 'default', which auto-creates a cluster if none is configured."),
     kafkaTopic: z.string().regex(K8S_NAMING_PATTERN).default("").optional()
-        .describe("Kafka topic for captured traffic. Empty defaults to the proxy name."),
-    source: z.string(),
+        .describe("Kafka topic name for captured traffic. If empty, defaults to the proxy name (the key in the proxies record)."),
+    source: z.string()
+        .describe("Name of the source cluster this proxy sits in front of. Must match a key in sourceClusters."),
     proxyConfig: USER_PROXY_OPTIONS
-});
+        .describe("Configuration for the capture proxy deployment and process options.")
+}).describe("Configuration for a single capture proxy instance, including its Kafka topic and source cluster binding.");
 
 export const SNAPSHOT_MIGRATION_FILTER = z.object({
-    source: z.string(),
+    source: z.string()
+        .describe("Name of the source cluster. Must match a key in sourceClusters."),
     snapshot: z.string()
-});
+        .describe("Name of the snapshot. Must match a key in the source cluster's snapshotInfo.snapshots.")
+}).describe("Reference to a specific snapshot from a specific source cluster, used to express dependencies.");
 
 export const REPLAYER_CONFIG = z.object({
-    skipApprovals: z.boolean().default(false).optional(), // TODO - format
-    fromProxy: z.string(),
-    toTarget: z.string(),
-    dependsOnSnapshotMigrations: z.array(SNAPSHOT_MIGRATION_FILTER).default([]).optional(),
+    skipApprovals: z.boolean().default(false).optional()
+        .describe("When true, skips all manual approval gates for this replayer."),
+    fromProxy: z.string()
+        .describe("Name of the capture proxy to replay traffic from. Must match a key in traffic.proxies."),
+    toTarget: z.string()
+        .describe("Name of the target cluster to replay traffic to. Must match a key in targetClusters."),
+    dependsOnSnapshotMigrations: z.array(SNAPSHOT_MIGRATION_FILTER).default([]).optional()
+        .describe("List of snapshot migrations that must complete before this replayer starts. Ensures data consistency when replaying traffic that depends on backfilled data."),
     replayerConfig: USER_REPLAYER_OPTIONS.optional()
-});
+        .describe("Optional replayer configuration overrides. If omitted, default replayer settings are used.")
+}).describe("Configuration for a single traffic replayer instance, binding a proxy's captured traffic to a target cluster.");
 
 export const TRAFFIC_CONFIG = z.object({
-    proxies: z.record(z.string().regex(K8S_NAMING_PATTERN), CAPTURE_CONFIG),
+    proxies: z.record(z.string().regex(K8S_NAMING_PATTERN), CAPTURE_CONFIG)
+        .describe("Map of proxy names to their capture configurations. Keys become the Kubernetes Service names and must be valid DNS labels."),
     replayers: z.record(z.string(), REPLAYER_CONFIG)
+        .describe("Map of replayer names to their replay configurations. Each replayer consumes from a proxy's Kafka topic and replays to a target cluster.")
 }).superRefine((data, ctx) => {
     for (const [name, rc] of Object.entries(data.replayers)) {
         if (!(rc.fromProxy in data.proxies)) {
@@ -485,40 +583,51 @@ export const TRAFFIC_CONFIG = z.object({
 
 export const EXTERNALLY_MANAGED_SNAPSHOT = z.object({
     externallyManagedSnapshotName: z.string()
-});
+        .describe("Name of a pre-existing snapshot in the source cluster's repository. The workflow will use this snapshot directly without creating a new one.")
+}).describe("Reference to a snapshot that was created outside of this migration workflow.");
 
 export const GENERATE_SNAPSHOT = z.object({
-    createSnapshotConfig: USER_CREATE_SNAPSHOT_OPTIONS,
+    createSnapshotConfig: USER_CREATE_SNAPSHOT_OPTIONS
+        .describe("Configuration for creating a new snapshot of the source cluster."),
     requiredForCompleteMigration: z.union([
-        z.object({toTargets: z.array(z.string())}),
+        z.object({toTargets: z.array(z.string())
+            .describe("List of target cluster names that require this snapshot for a complete migration.")
+        }),
         z.boolean().default(true).optional()
-    ])
-});
+    ]).describe("Whether this snapshot is required for migration completeness. Can be true/false or specify specific target clusters.")
+}).describe("Configuration to create a new snapshot of the source cluster as part of the migration workflow.");
 
 export const SNAPSHOT_NAME_CONFIG = z.union([
     EXTERNALLY_MANAGED_SNAPSHOT, GENERATE_SNAPSHOT
-]);
+]).describe("Snapshot source: either reference an existing snapshot or configure creation of a new one.");
 
 export const NORMALIZED_DYNAMIC_SNAPSHOT_CONFIG = z.object({
-    config: SNAPSHOT_NAME_CONFIG,
+    config: SNAPSHOT_NAME_CONFIG
+        .describe("Snapshot configuration: either an externally managed snapshot name or settings to create a new snapshot."),
     repoName: z.string()
-});
+        .describe("Name of the S3 snapshot repository. Must match a key in the source cluster's snapshotInfo.repos.")
+}).describe("A snapshot configuration bound to a specific repository.");
 
 export const SNAPSHOT_CONFIGS_MAP = z.record(
     z.string(),
     NORMALIZED_DYNAMIC_SNAPSHOT_CONFIG
-);
+).describe("Map of snapshot names to their configurations. Keys are used as labels and in snapshot name generation.");
 
 export const SNAPSHOT_INFO = z.object({
-    repos: SOURCE_CLUSTER_REPOS_RECORD.optional(),
+    repos: SOURCE_CLUSTER_REPOS_RECORD.optional()
+        .describe("S3 snapshot repositories registered with the source cluster."),
     snapshots: SNAPSHOT_CONFIGS_MAP
-})
+        .describe("Snapshots to use or create for this source cluster.")
+}).describe("Snapshot repository and snapshot configuration for a source cluster.");
 
 export const SOURCE_CLUSTER_CONFIG = CLUSTER_CONFIG.extend({
-    version: CLUSTER_VERSION_STRING,
-    enabled: z.boolean().default(true).optional(),
+    version: CLUSTER_VERSION_STRING
+        .describe("Version of the source cluster in '<ENGINE> <MAJOR>.<MINOR>.<PATCH>' format (e.g. 'ES 7.10.2', 'OS 1.3.0'). Required for compatibility checks and migration strategy selection."),
+    enabled: z.boolean().default(true).optional()
+        .describe("When false, this source cluster is excluded from the migration. Useful for temporarily disabling a source without removing its configuration."),
     snapshotInfo: SNAPSHOT_INFO.optional()
-}).superRefine((data, ctx) => {
+        .describe("Snapshot repository and snapshot configurations for this source cluster. Required if any snapshot-based migrations reference this source.")
+}).describe("Connection and snapshot configuration for a source Elasticsearch or OpenSearch cluster.").superRefine((data, ctx) => {
     const repos = data.snapshotInfo?.repos;
     const snapshots = data.snapshotInfo?.snapshots ?? {};
     for (const [snapName, snapConfig] of Object.entries(snapshots)) {
@@ -542,31 +651,41 @@ export const SOURCE_CLUSTER_CONFIG = CLUSTER_CONFIG.extend({
 });
 
 export const NORMALIZED_COMPLETE_SNAPSHOT_CONFIG = z.object({
-    snapshotName: z.string() // override to required
-});
+    snapshotName: z.string()
+        .describe("Resolved name of the snapshot to use for migration.")
+}).describe("A fully resolved snapshot configuration with a concrete snapshot name.");
 
 export const USER_PER_INDICES_SNAPSHOT_MIGRATION_CONFIG = z.object({
-    label: z.string().regex(/^[a-zA-Z][a-zA-Z0-9]*/).default("").optional(),
-    metadataMigrationConfig: USER_METADATA_OPTIONS.optional(),
-    documentBackfillConfig: USER_RFS_OPTIONS.optional(),
-}).refine(data =>
+    label: z.string().regex(/^[a-zA-Z][a-zA-Z0-9]*/).default("").optional()
+        .describe("Unique label for this migration within its snapshot group. Auto-generated as 'migration-<index>' if not specified. Must start with a letter and contain only alphanumeric characters."),
+    metadataMigrationConfig: USER_METADATA_OPTIONS.optional()
+        .describe("Configuration for migrating index metadata (mappings, settings, templates) from the snapshot to the target. Omit to skip metadata migration."),
+    documentBackfillConfig: USER_RFS_OPTIONS.optional()
+        .describe("Configuration for backfilling documents from the snapshot to the target using Reindex From Snapshot. Omit to skip document backfill."),
+}).describe("Configuration for a single migration pass from a snapshot. At least one of metadataMigrationConfig or documentBackfillConfig must be provided.").refine(data =>
         data.metadataMigrationConfig !== undefined ||
         data.documentBackfillConfig !== undefined,
     {message: "At least one of metadataMigrationConfig or documentBackfillConfig must be provided"});
 
 export const SNAPSHOT_MIGRATION_CONFIG_ARRAY =
-    z.array(USER_PER_INDICES_SNAPSHOT_MIGRATION_CONFIG);
+    z.array(USER_PER_INDICES_SNAPSHOT_MIGRATION_CONFIG)
+    .describe("Ordered list of migration passes to execute for a single snapshot. Each pass can include metadata migration, document backfill, or both.");
 
 export const PER_SNAPSHOT_MIGRATION_CONFIG_RECORD =
     z.record(z.string().regex(/^[a-zA-Z][a-zA-Z0-9]*/),
-        SNAPSHOT_MIGRATION_CONFIG_ARRAY.min(1));
+        SNAPSHOT_MIGRATION_CONFIG_ARRAY.min(1))
+    .describe("Map of snapshot names to their migration configurations. Keys must match snapshot names defined in the source cluster's snapshotInfo.snapshots.");
 
 export const NORMALIZED_PARAMETERIZED_MIGRATION_CONFIG = z.object({
-    skipApprovals : z.boolean().default(false).optional(), // TODO - format
-    fromSource: z.string(),
-    toTarget: z.string(),
-    perSnapshotConfig: PER_SNAPSHOT_MIGRATION_CONFIG_RECORD.optional(),
-}).superRefine((data, ctx) => {
+    skipApprovals : z.boolean().default(false).optional()
+        .describe("When true, skips all manual approval gates for migrations in this configuration block."),
+    fromSource: z.string()
+        .describe("Name of the source cluster to migrate from. Must match a key in sourceClusters."),
+    toTarget: z.string()
+        .describe("Name of the target cluster to migrate to. Must match a key in targetClusters."),
+    perSnapshotConfig: PER_SNAPSHOT_MIGRATION_CONFIG_RECORD.optional()
+        .describe("Per-snapshot migration configurations. Each entry maps a snapshot name to one or more migration passes (metadata + document backfill)."),
+}).describe("A snapshot-based migration configuration binding a source cluster to a target cluster with per-snapshot migration settings.").superRefine((data, ctx) => {
     if (!data.perSnapshotConfig) return;
     for (const [snapName, migrations] of Object.entries(data.perSnapshotConfig)) {
         const labels = migrations.map(m => m.label).filter(Boolean);
@@ -580,24 +699,31 @@ export const NORMALIZED_PARAMETERIZED_MIGRATION_CONFIG = z.object({
     }
 });
 
-export const KAFKA_CLUSTERS_MAP = z.record(z.string().regex(K8S_NAMING_PATTERN), KAFKA_CLUSTER_CONFIG);
-export const SOURCE_CLUSTERS_MAP = z.record(z.string(), SOURCE_CLUSTER_CONFIG);
-export const TARGET_CLUSTERS_MAP = z.record(z.string(), TARGET_CLUSTER_CONFIG);
+export const KAFKA_CLUSTERS_MAP = z.record(z.string().regex(K8S_NAMING_PATTERN), KAFKA_CLUSTER_CONFIG)
+    .describe("Map of Kafka cluster names to their configurations. Keys become Kubernetes resource names and must be valid DNS labels. If empty and proxies are configured, a 'default' auto-created cluster is used.");
+export const SOURCE_CLUSTERS_MAP = z.record(z.string(), SOURCE_CLUSTER_CONFIG)
+    .describe("Map of source cluster names to their configurations. Keys are used as labels throughout the migration workflow.");
+export const TARGET_CLUSTERS_MAP = z.record(z.string(), TARGET_CLUSTER_CONFIG)
+    .describe("Map of target cluster names to their configurations. Keys are used as labels and must be referenced by snapshotMigrationConfigs and traffic replayers.");
 
 export const OVERALL_MIGRATION_CONFIG = //validateOptionalDefaultConsistency
 (
     z.object({
-        skipApprovals : z.boolean().default(false).optional(), // TODO - format
-        kafkaClusterConfiguration: KAFKA_CLUSTERS_MAP.default({}).optional(),
-        sourceClusters: SOURCE_CLUSTERS_MAP,
-        targetClusters: TARGET_CLUSTERS_MAP,
-        snapshotMigrationConfigs: z.array(NORMALIZED_PARAMETERIZED_MIGRATION_CONFIG),
+        skipApprovals : z.boolean().default(false).optional()
+            .describe("Global flag to skip all manual approval gates across the entire migration. When true, overrides all per-component skipApproval settings."),
+        kafkaClusterConfiguration: KAFKA_CLUSTERS_MAP.default({}).optional()
+            .describe("Kafka cluster configurations. If empty and traffic capture is configured, a default ephemeral Kafka cluster is auto-created for each referenced cluster name."),
+        sourceClusters: SOURCE_CLUSTERS_MAP
+            .describe("Source Elasticsearch or OpenSearch clusters to migrate from."),
+        targetClusters: TARGET_CLUSTERS_MAP
+            .describe("Target OpenSearch clusters to migrate to."),
+        snapshotMigrationConfigs: z.array(NORMALIZED_PARAMETERIZED_MIGRATION_CONFIG)
+            .describe("List of snapshot-based migration configurations. Each entry binds a source cluster to a target cluster and defines which snapshots to migrate with what settings."),
         traffic: TRAFFIC_CONFIG
-            .describe("Top-level items are independent of each other but " +
-                "items in the inner-arrays require all snapshot activities across each of the items' " +
-                "sources to finish before any replays in this group can start.")
+            .describe("Traffic capture and replay configuration. Proxies capture live traffic from source clusters to Kafka, and replayers consume from Kafka to replay against target clusters. " +
+                "All top-level items are independent, but replayers can declare dependencies on snapshot migrations to ensure data consistency.")
             .optional()
-    }).superRefine((data, ctx) => {
+    }).describe("Top-level migration configuration defining source clusters, target clusters, snapshot migrations, and optional traffic capture/replay.").superRefine((data, ctx) => {
         for (let i = 0; i < data.snapshotMigrationConfigs.length; i++) {
             const mc = data.snapshotMigrationConfigs[i];
 

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -430,7 +430,9 @@ export const USER_RFS_PROCESS_OPTIONS = z.object({
         .describe("Maximum number of documents per bulk indexing request to the target cluster. Lower values reduce per-request latency but increase overhead."),
     documentsSizePerBulkRequest: z.number().default(10*1024*1024).optional()
         .describe("Maximum aggregate document size in bytes per bulk indexing request. Does not apply to single-document requests."),
-    initialLeaseDuration: z.string().default("PT1H").optional()
+    initialLeaseDuration: z.string()
+        .regex(/^[-+]?P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/)
+        .default("PT1H").optional()
         .describe("ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up."),
     maxConnections: z.number().default(10).optional()
         .describe("Maximum number of concurrent HTTP connections from each RFS worker to the target cluster for bulk indexing."),

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -310,7 +310,9 @@ export const USER_CREATE_SNAPSHOT_WORKFLOW_OPTIONS = z.object({
 
 export const USER_CREATE_SNAPSHOT_PROCESS_OPTIONS = z.object({
     indexAllowlist: z.array(z.string()).default([]).optional()
-        .describe("List of index name patterns to include in the snapshot. An empty list means all indices are included."),
+        .describe("List of index names to include in the snapshot. " +
+            "Each entry is either an exact index name (e.g. 'logs-2024-01') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*-2024'). " +
+            "An empty list includes all indices."),
     maxSnapshotRateMbPerNode: z.number().default(0).optional()
         .describe("Maximum snapshot throughput in MB/s per data node. 0 means no rate limiting. Use to reduce I/O impact on the source cluster during snapshot creation."),
     compressionEnabled: z.boolean().default(false).optional()
@@ -340,11 +342,17 @@ export const USER_METADATA_WORKFLOW_OPTIONS = z.object({
 
 export const USER_METADATA_PROCESS_OPTIONS = z.object({
     componentTemplateAllowlist: z.array(z.string()).default([]).optional()
-        .describe("List of component template name patterns to include in the metadata migration. An empty list means all component templates are included."),
+        .describe("List of component template names to include in the metadata migration. " +
+            "Each entry is either an exact name or a regex pattern prefixed with 'regex:'. " +
+            "An empty list includes all non-system component templates."),
     indexAllowlist: z.array(z.string()).default([]).optional()
-        .describe("List of index name patterns to include in the metadata migration. An empty list means all indices are included."),
+        .describe("List of index names to include in the metadata migration. " +
+            "Each entry is either an exact index name (e.g. 'my-index') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). " +
+            "An empty list includes all non-system indices."),
     indexTemplateAllowlist: z.array(z.string()).default([]).optional()
-        .describe("List of index template name patterns to include in the metadata migration. An empty list means all index templates are included."),
+        .describe("List of index template names to include in the metadata migration. " +
+            "Each entry is either an exact name or a regex pattern prefixed with 'regex:'. " +
+            "An empty list includes all non-system index templates."),
 
     allowLooseVersionMatching: z.boolean().default(true).optional()
         .describe("When true, allows metadata migration between clusters with non-exact version compatibility (e.g. ES 7.x to OS 2.x). When false, requires strict version matching."),
@@ -400,7 +408,9 @@ export const USER_RFS_WORKFLOW_OPTIONS = z.object({
 
 export const USER_RFS_PROCESS_OPTIONS = z.object({
     indexAllowlist: z.array(z.string()).default([]).optional()
-        .describe("List of index name patterns to include in the document backfill. An empty list means all indices from the snapshot are migrated."),
+        .describe("List of index names to include in the document backfill. " +
+            "Each entry is either an exact index name or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). " +
+            "An empty list includes all non-system indices from the snapshot."),
     allowLooseVersionMatching: z.boolean().default(true).optional()
         .describe("When true, allows document migration between clusters with non-exact version compatibility."),
     docTransformerConfigBase64: z.string().default("").optional()

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -97,9 +97,8 @@ export const S3_REPO_CONFIG = z.object({
     awsRegion: z.string()
         .describe("AWS region where the S3 bucket resides (e.g. 'us-east-2'). Used for S3 client configuration and snapshot repository registration."),
     endpoint: z.string().regex(/(?:^(http|localstack)s?:\/\/[^/]*\/?$)?/).default("").optional()
-        .describe("Override the default S3 endpoint URL. Supports http://, https://, localstack://, and localstacks:// schemes. " +
-            "LocalStack endpoints are automatically resolved to IP addresses during config transformation. " +
-            "Leave empty to use the default AWS S3 endpoint."),
+        .describe("Override the S3 endpoint URL. Supports http://, https://, localstack://, and localstacks:// schemes. " +
+            "LocalStack endpoints are automatically resolved to IP addresses during config transformation."),
     s3RepoPathUri: z.string().regex(/^s3:\/\/[a-z0-9][a-z0-9.-]{1,61}[a-z0-9](\/[a-zA-Z0-9!\-_.*'()/]*)?$/)
         .describe("S3 URI for the snapshot repository in the format 's3://BUCKET_NAME/OPTIONAL_PATH'. " +
             "The bucket must already exist and be accessible from the source cluster."),
@@ -175,9 +174,9 @@ export const PROXY_TLS_CONFIG = z.discriminatedUnion("mode", [
         dnsNames: z.array(z.string()).min(1)
             .describe("DNS Subject Alternative Names for the certificate. Must include the proxy's Kubernetes service DNS name (e.g. 'my-proxy.default.svc.cluster.local')."),
         duration: z.string().default("2160h").optional()
-            .describe("Requested certificate validity duration in Go duration format. Default is '2160h' (90 days)."),
+            .describe("Requested certificate validity duration in Go duration format (e.g. '2160h' = 90 days)."),
         renewBefore: z.string().default("360h").optional()
-            .describe("How long before certificate expiry to trigger renewal. Default is '360h' (15 days)."),
+            .describe("How long before certificate expiry to trigger renewal (e.g. '360h' = 15 days)."),
     }).describe("Provision a TLS certificate via cert-manager. A Certificate resource is created and the resulting secret is mounted into the proxy pod."),
     z.object({
         mode: z.literal("existingSecret")
@@ -189,23 +188,23 @@ export const PROXY_TLS_CONFIG = z.discriminatedUnion("mode", [
 
 export const USER_PROXY_WORKFLOW_OPTIONS = z.object({
     loggingConfigurationOverrideConfigMap: z.string().default("").optional()
-        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration. When set, the ConfigMap is mounted into the container and used to override default logging. Leave empty to use built-in logging defaults."),
+        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration. When set, the ConfigMap is mounted into the container to override logging behavior."),
     internetFacing: z.boolean().default(false).optional()
-        .describe("When true, the proxy's Kubernetes Service is annotated with 'internet-facing' load balancer scheme, making it accessible from outside the VPC. When false (default), the load balancer is internal-only."),
+        .describe("When true, the proxy's Kubernetes Service is annotated with 'internet-facing' load balancer scheme, making it accessible from outside the VPC."),
     podReplicas: z.number().default(1).optional()
         .describe("Number of proxy pod replicas in the Kubernetes Deployment. Increase for higher throughput or availability."),
     resources: z.preprocess((v) => deepmerge(DEFAULT_RESOURCES.PROXY, (v ?? {})), RESOURCE_REQUIREMENTS)
-        .describe("Kubernetes resource limits and requests for the capture proxy container. Defaults to 3500m CPU and 3500Mi memory for both limits and requests (Guaranteed QoS).")
+        .describe("Kubernetes resource limits and requests for the capture proxy container. Partial overrides are deep-merged with the built-in defaults (Guaranteed QoS).")
         .default(DEFAULT_RESOURCES.PROXY),
 }).describe("Kubernetes deployment-level options for the capture proxy.");
 
 export const USER_PROXY_PROCESS_OPTIONS = z.object({
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
-        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector. The proxy sends metrics and traces to this endpoint. Default points to the in-cluster collector service."),
+        .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector. The proxy sends metrics and traces to this endpoint."),
     setHeader: z.array(z.string()).optional()
         .describe("List of static headers to add to proxied requests, each in 'Header-Name: value' format."),
     destinationConnectionPoolSize: z.number().default(0).optional()
-        .describe("Maximum number of persistent connections to the destination (source) cluster. 0 means unlimited/default connection pooling."),
+        .describe("Maximum number of persistent connections to the destination (source) cluster. 0 means unlimited connection pooling."),
     destinationConnectionPoolTimeout: z.string()
         .regex(/^[-+]?P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/)
         .default("PT30S").optional()
@@ -215,7 +214,7 @@ export const USER_PROXY_PROCESS_OPTIONS = z.object({
     listenPort: z.number()
         .describe("TCP port the capture proxy listens on for incoming HTTP(S) traffic. This port is exposed via the Kubernetes Service and used to construct the proxy endpoint URL."),
     maxTrafficBufferSize: z.number().default(1048576).optional()
-        .describe("Maximum size in bytes for buffering a single HTTP request/response payload before forwarding to Kafka. Default is 1048576 (1 MiB)."),
+        .describe("Maximum size in bytes for buffering a single HTTP request/response payload before forwarding to Kafka."),
     noCapture: z.boolean().default(false).optional()
         .describe("When true, the proxy forwards traffic to the source cluster without capturing it to Kafka. Useful for TLS termination or routing without traffic recording."),
     numThreads: z.number().default(1).optional()
@@ -246,13 +245,13 @@ export const USER_PROXY_OPTIONS = z.object({
 
 export const USER_REPLAYER_WORKFLOW_OPTIONS = z.object({
     jvmArgs: z.string().default("").optional()
-        .describe("Additional JVM arguments passed to the replayer process via JDK_JAVA_OPTIONS (e.g. '-Xmx4g -XX:+UseG1GC'). Leave empty for JVM defaults."),
+        .describe("Additional JVM arguments passed to the replayer process via JDK_JAVA_OPTIONS (e.g. '-Xmx4g -XX:+UseG1GC')."),
     loggingConfigurationOverrideConfigMap: z.string().default("").optional()
-        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the replayer. Leave empty to use built-in logging defaults."),
+        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the replayer."),
     podReplicas: z.number().default(1).optional()
         .describe("Number of replayer pod replicas in the Kubernetes Deployment. Each replica independently consumes from Kafka and replays traffic to the target."),
     resources: z.preprocess((v) => deepmerge(DEFAULT_RESOURCES.REPLAYER, (v ?? {})), RESOURCE_REQUIREMENTS)
-        .describe("Kubernetes resource limits and requests for the replayer container. Defaults to 3500m CPU and 3500Mi memory (Guaranteed QoS)."),
+        .describe("Kubernetes resource limits and requests for the replayer container. Partial overrides are deep-merged with the built-in defaults (Guaranteed QoS)."),
 }).describe("Kubernetes deployment-level options for the traffic replayer.");
 
 export const USER_REPLAYER_PROCESS_OPTIONS = z.object({
@@ -265,7 +264,7 @@ export const USER_REPLAYER_PROCESS_OPTIONS = z.object({
     maxConcurrentRequests: z.number().default(10000).optional()
         .describe("Maximum number of HTTP requests that can be in-flight simultaneously to the target cluster. Limits concurrency to prevent overwhelming the target."),
     numClientThreads: z.number().default(0).optional()
-        .describe("Number of threads used to send replayed requests to the target. 0 uses the Netty default (typically number of available processors)."),
+        .describe("Number of threads used to send replayed requests to the target. 0 uses the Netty event loop (typically number of available processors)."),
     observedPacketConnectionTimeout: z.number().default(360).optional()
         .describe("Seconds of inactivity on a captured connection before assuming it was terminated in the original traffic stream."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
@@ -275,7 +274,7 @@ export const USER_REPLAYER_PROCESS_OPTIONS = z.object({
     removeAuthHeader: z.boolean().default(false).optional()
         .describe("Remove the Authorization header from replayed requests without replacing it. Useful when the target uses a different auth mechanism (e.g. SigV4) configured separately."),
     speedupFactor: z.number().default(1.1).optional()
-        .describe("Multiplier to accelerate replay timing relative to the original captured traffic. 1.0 = real-time, 2.0 = double speed. Default 1.1 provides a slight speedup to keep replay ahead of capture."),
+        .describe("Multiplier to accelerate replay timing relative to the original captured traffic. 1.0 = real-time, 2.0 = double speed."),
     targetServerResponseTimeoutSeconds: z.number().default(150).optional()
         .describe("Maximum seconds to wait for a response from the target cluster before timing out a replayed request."),
     transformerConfig: z.string().optional()
@@ -310,7 +309,7 @@ export const USER_CREATE_SNAPSHOT_WORKFLOW_OPTIONS = z.object({
     jvmArgs: z.string().default("").optional()
         .describe("Additional JVM arguments passed to the CreateSnapshot process via JDK_JAVA_OPTIONS (e.g. '-Xmx2g')."),
     loggingConfigurationOverrideConfigMap: z.string().default("").optional()
-        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the snapshot creation process. Leave empty for defaults.")
+        .describe("Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the snapshot creation process.")
 }).describe("Workflow-level options for snapshot creation, controlling naming and JVM configuration.");
 
 export const USER_CREATE_SNAPSHOT_PROCESS_OPTIONS = z.object({
@@ -394,7 +393,7 @@ export const USER_RFS_WORKFLOW_OPTIONS = z.object({
                     ),
             }),
         }))
-        .describe("Kubernetes resource limits and requests for the RFS container. Defaults to 3300m CPU and 7000Mi memory. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."),
+        .describe("Kubernetes resource limits and requests for the RFS container. Partial overrides are deep-merged with the built-in defaults. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."),
 }).describe("Kubernetes deployment-level options for the Reindex From Snapshot (RFS) document backfill.");
 
 export const USER_RFS_PROCESS_OPTIONS = z.object({
@@ -405,13 +404,13 @@ export const USER_RFS_PROCESS_OPTIONS = z.object({
     docTransformerConfigBase64: z.string().default("").optional()
         .describe("Base64-encoded JSON configuration for document transformers. Defines custom transformations applied to each document during the backfill (e.g. field renaming, type conversion)."),
     documentsPerBulkRequest: z.number().default(0x7fffffff).optional()
-        .describe("Maximum number of documents per bulk indexing request to the target cluster. Default is 2147483647 (effectively unlimited, bounded by request size). Lower values reduce per-request latency but increase overhead."),
+        .describe("Maximum number of documents per bulk indexing request to the target cluster. Lower values reduce per-request latency but increase overhead."),
     initialLeaseDuration: z.string().default("PT1H").optional()
         .describe("ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up."),
     maxConnections: z.number().default(10).optional()
         .describe("Maximum number of concurrent HTTP connections from each RFS worker to the target cluster for bulk indexing."),
     maxShardSizeBytes: z.number().default(80*1024*1024*1024).optional()
-        .describe("Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Default is 85899345920 (80 GiB). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."),
+        .describe("Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
         .describe("gRPC endpoint (host:port) for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."),
 }).describe("Process-level options for the RFS document backfill command, controlling indexing behavior, concurrency, and transformations.");
@@ -474,7 +473,7 @@ export const KAFKA_CLUSTER_CREATION_CONFIG = z.object({
                    ]).default({ type: "ephemeral" }).optional()
                    .describe("Storage configuration for Kafka broker data."),
     partitions:    z.number().int().min(1).default(1).optional()
-        .describe("Default number of partitions for auto-created Kafka topics. More partitions enable higher parallelism for consumers."),
+        .describe("Number of partitions for auto-created Kafka topics. More partitions enable higher parallelism for consumers."),
     topicReplicas: z.number().int().min(1).default(1).optional()
         .describe("Replication factor for auto-created Kafka topics. Must not exceed the number of broker replicas. Higher values improve durability."),
 }).describe("Configuration for auto-creating a Strimzi Kafka cluster. Used when no existing Kafka cluster is provided.");
@@ -562,7 +561,7 @@ export const REPLAYER_CONFIG = z.object({
     dependsOnSnapshotMigrations: z.array(SNAPSHOT_MIGRATION_FILTER).default([]).optional()
         .describe("List of snapshot migrations that must complete before this replayer starts. Ensures data consistency when replaying traffic that depends on backfilled data."),
     replayerConfig: USER_REPLAYER_OPTIONS.optional()
-        .describe("Optional replayer configuration overrides. If omitted, default replayer settings are used.")
+        .describe("Optional replayer configuration overrides. If omitted, replayer runs with schema defaults.")
 }).describe("Configuration for a single traffic replayer instance, binding a proxy's captured traffic to a target cluster.");
 
 export const TRAFFIC_CONFIG = z.object({

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -104,8 +104,9 @@ export const S3_REPO_CONFIG = z.object({
         .describe("S3 URI for the snapshot repository in the format 's3://BUCKET_NAME/OPTIONAL_PATH'. " +
             "The bucket must already exist and be accessible from the source cluster."),
     s3RoleArn: z.string().regex(/^(arn:aws:iam::\d{12}:(user|role|group|policy)\/[a-zA-Z0-9+=,.@_-]+)?$/).default("").optional()
-        .describe("IAM role ARN to assume when accessing S3 for snapshot operations. " +
-            "Leave empty to use the default credentials of the migration infrastructure.")
+        .describe("IAM role ARN that the source cluster will assume to read/write snapshots to S3. " +
+            "This is passed to the cluster when registering the snapshot repository. " +
+            "Leave empty if the cluster's own IAM role already has S3 access.")
 }).describe("Configuration for an S3-backed snapshot repository used by the source cluster.");
 
 export const PORT_NUMBER_PATTERN = "(?:[1-9]\\d{0,3}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])";

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -233,7 +233,16 @@ export const USER_PROXY_PROCESS_OPTIONS = z.object({
         .describe("URI path pattern to suppress from capture. Requests matching this path are forwarded but not recorded."),
     suppressMethodAndPath: z.string().default("").optional()
         .describe("Combined method and path pattern for capture suppression in 'METHOD /path' format."),
-}).describe("Process-level configuration options for the capture proxy application. These are passed as command-line arguments to the proxy container.");
+}).describe("Process-level configuration options for the capture proxy application. These are passed as command-line arguments to the proxy container.")
+.superRefine((data, ctx) => {
+    if (data.sslConfigFile && data.tls) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "sslConfigFile and tls are mutually exclusive. Use tls for Kubernetes deployments or sslConfigFile for legacy non-Kubernetes deployments.",
+            path: ['tls']
+        });
+    }
+});
 
 export const USER_PROXY_WORKFLOW_OPTION_KEYS = getZodKeys(USER_PROXY_WORKFLOW_OPTIONS);
 export const USER_PROXY_PROCESS_OPTION_KEYS = getZodKeys(USER_PROXY_PROCESS_OPTIONS);

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -260,13 +260,13 @@ export const USER_REPLAYER_PROCESS_OPTIONS = z.object({
     kafkaTrafficPropertyFile: z.string().optional()
         .describe("Path to a Java properties file with additional or overridden Kafka consumer configuration. Mounted into the replayer container."),
     lookaheadTimeSeconds: z.number().default(400).optional()
-        .describe("Number of seconds of captured traffic to buffer ahead of the current replay position. Larger values improve throughput but increase memory usage."),
+        .describe("Number of seconds of captured traffic to buffer ahead of the current replay position. Must be strictly greater than observedPacketConnectionTimeout. Larger values improve throughput but increase memory usage."),
     maxConcurrentRequests: z.number().default(10000).optional()
         .describe("Maximum number of HTTP requests that can be in-flight simultaneously to the target cluster. Limits concurrency to prevent overwhelming the target."),
     numClientThreads: z.number().default(0).optional()
         .describe("Number of threads used to send replayed requests to the target. 0 uses the Netty event loop (typically number of available processors)."),
     observedPacketConnectionTimeout: z.number().default(360).optional()
-        .describe("Seconds of inactivity on a captured connection before assuming it was terminated in the original traffic stream."),
+        .describe("Seconds of inactivity on a captured connection before assuming it was terminated in the original traffic stream. Must be strictly less than lookaheadTimeSeconds."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
         .describe("URL for the OpenTelemetry Collector to which the replayer sends metrics and traces."),
     quiescentPeriodMs: z.number().default(5000).optional()

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -303,6 +303,15 @@ export const USER_REPLAYER_PROCESS_OPTION_KEYS = getZodKeys(USER_REPLAYER_PROCES
 export const USER_REPLAYER_OPTIONS = z.object({
     ...USER_REPLAYER_WORKFLOW_OPTIONS.shape,
     ...USER_REPLAYER_PROCESS_OPTIONS.shape,
+}).superRefine((data, ctx) => {
+    if (data.lookaheadTimeSeconds !== undefined && data.observedPacketConnectionTimeout !== undefined
+        && data.lookaheadTimeSeconds <= data.observedPacketConnectionTimeout) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `lookaheadTimeSeconds (${data.lookaheadTimeSeconds}) must be strictly greater than observedPacketConnectionTimeout (${data.observedPacketConnectionTimeout})`,
+            path: ['lookaheadTimeSeconds']
+        });
+    }
 });
 
 // Note: noWait is not included here as it is hardcoded to true in the workflow.
@@ -366,14 +375,14 @@ export const USER_METADATA_PROCESS_OPTIONS = z.object({
         .describe("When true, allows metadata migration between clusters with non-exact version compatibility (e.g. ES 7.x to OS 2.x). When false, requires strict version matching."),
     clusterAwarenessAttributes: z.number().default(1).optional()
         .describe("Number of shard allocation awareness attributes to preserve during metadata migration. Controls how index settings related to cluster topology are handled."),
-    multiTypeBehavior: z.union(["NONE", "UNION", "SPLIT"].map(s=>z.literal(s))).default("NONE").optional()
+    multiTypeBehavior: z.enum(["NONE", "UNION", "SPLIT"]).default("NONE").optional()
         .describe("Strategy for handling Elasticsearch multi-type indices (ES 5.x and earlier). " +
             "'NONE': fail if multi-type indices are encountered. " +
             "'UNION': merge all types into a single mapping. " +
             "'SPLIT': create separate indices for each type."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
         .describe("URL for the OpenTelemetry Collector for metadata migration metrics."),
-    output: z.union(["HUMAN_READABLE", "JSON"].map(s=>z.literal(s))).default("HUMAN_READABLE").optional()
+    output: z.enum(["HUMAN_READABLE", "JSON"]).default("HUMAN_READABLE").optional()
         .describe("Output format for the metadata migration evaluation report. 'HUMAN_READABLE' for formatted text, 'JSON' for machine-parseable output."),
     transformerConfigBase64: z.string().default("").optional()
         .describe("Base64-encoded JSON configuration for metadata transformers. Defines custom transformations applied to index mappings and settings during migration."),
@@ -439,7 +448,7 @@ export const USER_RFS_PROCESS_OPTIONS = z.object({
         .describe("Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional()
         .describe("URL for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."),
-    serverGeneratedIds: z.union(["AUTO", "ALWAYS", "NEVER"].map(s=>z.literal(s))).default("AUTO").optional()
+    serverGeneratedIds: z.enum(["AUTO", "ALWAYS", "NEVER"]).default("AUTO").optional()
         .describe("Controls document ID generation on the target. " +
             "'AUTO': auto-detect serverless TIMESERIES/VECTOR collections and enable server-generated IDs. " +
             "'ALWAYS': always use server-generated IDs (discards source IDs). " +

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -724,25 +724,11 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "default": 1
                           },
                           "multiTypeBehavior": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "NONE"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "UNION"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "SPLIT"
-                                ]
-                              }
+                            "type": "string",
+                            "enum": [
+                              "NONE",
+                              "UNION",
+                              "SPLIT"
                             ],
                             "default": "NONE"
                           },
@@ -751,19 +737,10 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "default": "http://otel-collector:4317"
                           },
                           "output": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "HUMAN_READABLE"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "JSON"
-                                ]
-                              }
+                            "type": "string",
+                            "enum": [
+                              "HUMAN_READABLE",
+                              "JSON"
                             ],
                             "default": "HUMAN_READABLE"
                           },
@@ -903,25 +880,11 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "default": "http://otel-collector:4317"
                           },
                           "serverGeneratedIds": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "AUTO"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "ALWAYS"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "NEVER"
-                                ]
-                              }
+                            "type": "string",
+                            "enum": [
+                              "AUTO",
+                              "ALWAYS",
+                              "NEVER"
                             ],
                             "default": "AUTO"
                           },
@@ -2035,25 +1998,11 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         "description": "Number of shard allocation awareness attributes to preserve during metadata migration. Controls how index settings related to cluster topology are handled."
                       },
                       "multiTypeBehavior": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "NONE"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "UNION"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "SPLIT"
-                            ]
-                          }
+                        "type": "string",
+                        "enum": [
+                          "NONE",
+                          "UNION",
+                          "SPLIT"
                         ],
                         "default": "NONE",
                         "description": "Strategy for handling Elasticsearch multi-type indices (ES 5.x and earlier). 'NONE': fail if multi-type indices are encountered. 'UNION': merge all types into a single mapping. 'SPLIT': create separate indices for each type."
@@ -2064,19 +2013,10 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         "description": "URL for the OpenTelemetry Collector for metadata migration metrics."
                       },
                       "output": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "HUMAN_READABLE"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "JSON"
-                            ]
-                          }
+                        "type": "string",
+                        "enum": [
+                          "HUMAN_READABLE",
+                          "JSON"
                         ],
                         "default": "HUMAN_READABLE",
                         "description": "Output format for the metadata migration evaluation report. 'HUMAN_READABLE' for formatted text, 'JSON' for machine-parseable output."
@@ -2236,25 +2176,11 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         "description": "URL for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."
                       },
                       "serverGeneratedIds": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "AUTO"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ALWAYS"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "NEVER"
-                            ]
-                          }
+                        "type": "string",
+                        "enum": [
+                          "AUTO",
+                          "ALWAYS",
+                          "NEVER"
                         ],
                         "default": "AUTO",
                         "description": "Controls document ID generation on the target. 'AUTO': auto-detect serverless TIMESERIES/VECTOR collections and enable server-generated IDs. 'ALWAYS': always use server-generated IDs (discards source IDs). 'NEVER': always preserve source document IDs (may fail on serverless TIMESERIES/VECTOR collections)."

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -436,6 +436,14 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           "maxSnapshotRateMbPerNode": {
                             "type": "number",
                             "default": 0
+                          },
+                          "compressionEnabled": {
+                            "type": "boolean",
+                            "default": false
+                          },
+                          "includeGlobalState": {
+                            "type": "boolean",
+                            "default": true
                           }
                         }
                       },
@@ -762,6 +770,14 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           "transformerConfigBase64": {
                             "type": "string",
                             "default": ""
+                          },
+                          "transformerConfig": {
+                            "type": "string",
+                            "description": "Inline JSON configuration for metadata transformers. Keys are transformer names and values are their configuration. Alternative to transformerConfigBase64 for simple configurations."
+                          },
+                          "transformerConfigFile": {
+                            "type": "string",
+                            "description": "Path to a JSON file containing metadata transformer configuration. The file is read from the container filesystem."
                           }
                         }
                       },
@@ -861,9 +877,21 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "type": "string",
                             "default": ""
                           },
+                          "docTransformerConfig": {
+                            "type": "string",
+                            "description": "Inline JSON configuration for document transformers. Keys are transformer names and values are their configuration. Alternative to docTransformerConfigBase64 for simple configurations."
+                          },
+                          "docTransformerConfigFile": {
+                            "type": "string",
+                            "description": "Path to a JSON file containing document transformer configuration. The file is read from the container filesystem."
+                          },
                           "documentsPerBulkRequest": {
                             "type": "number",
                             "default": 2147483647
+                          },
+                          "documentsSizePerBulkRequest": {
+                            "type": "number",
+                            "default": 10485760
                           },
                           "initialLeaseDuration": {
                             "type": "string",
@@ -880,6 +908,48 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           "otelCollectorEndpoint": {
                             "type": "string",
                             "default": "http://otel-collector:4317"
+                          },
+                          "serverGeneratedIds": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "AUTO"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "ALWAYS"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NEVER"
+                                ]
+                              }
+                            ],
+                            "default": "AUTO"
+                          },
+                          "allowedDocExceptionTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "default": []
+                          },
+                          "coordinatorRetryMaxRetries": {
+                            "type": "number",
+                            "default": 7
+                          },
+                          "coordinatorRetryInitialDelayMs": {
+                            "type": "number",
+                            "default": 1000
+                          },
+                          "coordinatorRetryMaxDelayMs": {
+                            "type": "number",
+                            "default": 64000
                           }
                         }
                       }
@@ -1711,6 +1781,16 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                                   "type": "number",
                                   "default": 0,
                                   "description": "Maximum snapshot throughput in MB/s per data node. 0 means no rate limiting. Use to reduce I/O impact on the source cluster during snapshot creation."
+                                },
+                                "compressionEnabled": {
+                                  "type": "boolean",
+                                  "default": false,
+                                  "description": "When true, enables metadata compression for the snapshot. Reduces snapshot size at the cost of slightly increased CPU usage during creation."
+                                },
+                                "includeGlobalState": {
+                                  "type": "boolean",
+                                  "default": true,
+                                  "description": "When true, includes cluster global state (persistent settings, templates, etc.) in the snapshot."
                                 }
                               },
                               "description": "Configuration for creating a new snapshot of the source cluster."
@@ -2020,6 +2100,14 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         "type": "string",
                         "default": "",
                         "description": "Base64-encoded JSON configuration for metadata transformers. Defines custom transformations applied to index mappings and settings during migration."
+                      },
+                      "transformerConfig": {
+                        "type": "string",
+                        "description": "Inline JSON configuration for metadata transformers. Keys are transformer names and values are their configuration. Alternative to transformerConfigBase64 for simple configurations."
+                      },
+                      "transformerConfigFile": {
+                        "type": "string",
+                        "description": "Path to a JSON file containing metadata transformer configuration. The file is read from the container filesystem."
                       }
                     },
                     "description": "Configuration for migrating index metadata (mappings, settings, templates) from the snapshot to the target. Omit to skip metadata migration."
@@ -2131,10 +2219,23 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         "default": "",
                         "description": "Base64-encoded JSON configuration for document transformers. Defines custom transformations applied to each document during the backfill (e.g. field renaming, type conversion)."
                       },
+                      "docTransformerConfig": {
+                        "type": "string",
+                        "description": "Inline JSON configuration for document transformers. Keys are transformer names and values are their configuration. Alternative to docTransformerConfigBase64 for simple configurations."
+                      },
+                      "docTransformerConfigFile": {
+                        "type": "string",
+                        "description": "Path to a JSON file containing document transformer configuration. The file is read from the container filesystem."
+                      },
                       "documentsPerBulkRequest": {
                         "type": "number",
                         "default": 2147483647,
                         "description": "Maximum number of documents per bulk indexing request to the target cluster. Lower values reduce per-request latency but increase overhead."
+                      },
+                      "documentsSizePerBulkRequest": {
+                        "type": "number",
+                        "default": 10485760,
+                        "description": "Maximum aggregate document size in bytes per bulk indexing request. Does not apply to single-document requests."
                       },
                       "initialLeaseDuration": {
                         "type": "string",
@@ -2155,6 +2256,53 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         "type": "string",
                         "default": "http://otel-collector:4317",
                         "description": "URL for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."
+                      },
+                      "serverGeneratedIds": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "AUTO"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "ALWAYS"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "NEVER"
+                            ]
+                          }
+                        ],
+                        "default": "AUTO",
+                        "description": "Controls document ID generation on the target. 'AUTO': auto-detect serverless TIMESERIES/VECTOR collections and enable server-generated IDs. 'ALWAYS': always use server-generated IDs (discards source IDs). 'NEVER': always preserve source document IDs (may fail on serverless TIMESERIES/VECTOR collections)."
+                      },
+                      "allowedDocExceptionTypes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": [],
+                        "description": "List of document-level exception types to treat as successful operations during bulk migration. Enables idempotent migrations by allowing specific errors (e.g. 'version_conflict_engine_exception') to be treated as success rather than failure."
+                      },
+                      "coordinatorRetryMaxRetries": {
+                        "type": "number",
+                        "default": 7,
+                        "description": "Maximum number of retries when marking work items as completed on the coordinator."
+                      },
+                      "coordinatorRetryInitialDelayMs": {
+                        "type": "number",
+                        "default": 1000,
+                        "description": "Initial delay in milliseconds for coordinator completion retries. Doubles with each attempt up to coordinatorRetryMaxDelayMs."
+                      },
+                      "coordinatorRetryMaxDelayMs": {
+                        "type": "number",
+                        "default": 64000,
+                        "description": "Maximum delay in milliseconds for any single coordinator completion retry."
                       }
                     },
                     "description": "Configuration for backfilling documents from the snapshot to the target using Reindex From Snapshot. Omit to skip document backfill."

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -1759,7 +1759,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                                     "type": "string"
                                   },
                                   "default": [],
-                                  "description": "List of index name patterns to include in the snapshot. An empty list means all indices are included."
+                                  "description": "List of index names to include in the snapshot. Each entry is either an exact index name (e.g. 'logs-2024-01') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*-2024'). An empty list includes all indices."
                                 },
                                 "maxSnapshotRateMbPerNode": {
                                   "type": "number",
@@ -2005,7 +2005,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "type": "string"
                         },
                         "default": [],
-                        "description": "List of component template name patterns to include in the metadata migration. An empty list means all component templates are included."
+                        "description": "List of component template names to include in the metadata migration. Each entry is either an exact name or a regex pattern prefixed with 'regex:'. An empty list includes all non-system component templates."
                       },
                       "indexAllowlist": {
                         "type": "array",
@@ -2013,7 +2013,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "type": "string"
                         },
                         "default": [],
-                        "description": "List of index name patterns to include in the metadata migration. An empty list means all indices are included."
+                        "description": "List of index names to include in the metadata migration. Each entry is either an exact index name (e.g. 'my-index') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). An empty list includes all non-system indices."
                       },
                       "indexTemplateAllowlist": {
                         "type": "array",
@@ -2021,7 +2021,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "type": "string"
                         },
                         "default": [],
-                        "description": "List of index template name patterns to include in the metadata migration. An empty list means all index templates are included."
+                        "description": "List of index template names to include in the metadata migration. Each entry is either an exact name or a regex pattern prefixed with 'regex:'. An empty list includes all non-system index templates."
                       },
                       "allowLooseVersionMatching": {
                         "type": "boolean",
@@ -2187,7 +2187,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "type": "string"
                         },
                         "default": [],
-                        "description": "List of index name patterns to include in the document backfill. An empty list means all indices from the snapshot are migrated."
+                        "description": "List of index names to include in the document backfill. Each entry is either an exact index name or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). An empty list includes all non-system indices from the snapshot."
                       },
                       "allowLooseVersionMatching": {
                         "type": "boolean",

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -774,10 +774,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           "transformerConfig": {
                             "type": "string",
                             "description": "Inline JSON configuration for metadata transformers. Keys are transformer names and values are their configuration. Alternative to transformerConfigBase64 for simple configurations."
-                          },
-                          "transformerConfigFile": {
-                            "type": "string",
-                            "description": "Path to a JSON file containing metadata transformer configuration. The file is read from the container filesystem."
                           }
                         }
                       },
@@ -880,10 +876,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           "docTransformerConfig": {
                             "type": "string",
                             "description": "Inline JSON configuration for document transformers. Keys are transformer names and values are their configuration. Alternative to docTransformerConfigBase64 for simple configurations."
-                          },
-                          "docTransformerConfigFile": {
-                            "type": "string",
-                            "description": "Path to a JSON file containing document transformer configuration. The file is read from the container filesystem."
                           },
                           "documentsPerBulkRequest": {
                             "type": "number",
@@ -1313,10 +1305,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                       "type": "string",
                       "description": "Base64-encoded request transformer configuration. Alternative to transformerConfig for configurations containing special characters."
                     },
-                    "transformerConfigFile": {
-                      "type": "string",
-                      "description": "Path to a JSON file containing request transformer configuration. The file is read from the container filesystem."
-                    },
                     "tupleTransformerConfig": {
                       "type": "string",
                       "description": "Inline tuple transformer configuration as a JSON string. Tuple transformers operate on request-response pairs for stateful transformations."
@@ -1324,10 +1312,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     "tupleTransformerConfigBase64": {
                       "type": "string",
                       "description": "Base64-encoded tuple transformer configuration."
-                    },
-                    "tupleTransformerConfigFile": {
-                      "type": "string",
-                      "description": "Path to a JSON file containing tuple transformer configuration."
                     },
                     "userAgent": {
                       "type": "string",
@@ -2104,10 +2088,6 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "transformerConfig": {
                         "type": "string",
                         "description": "Inline JSON configuration for metadata transformers. Keys are transformer names and values are their configuration. Alternative to transformerConfigBase64 for simple configurations."
-                      },
-                      "transformerConfigFile": {
-                        "type": "string",
-                        "description": "Path to a JSON file containing metadata transformer configuration. The file is read from the container filesystem."
                       }
                     },
                     "description": "Configuration for migrating index metadata (mappings, settings, templates) from the snapshot to the target. Omit to skip metadata migration."
@@ -2222,10 +2202,6 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "docTransformerConfig": {
                         "type": "string",
                         "description": "Inline JSON configuration for document transformers. Keys are transformer names and values are their configuration. Alternative to docTransformerConfigBase64 for simple configurations."
-                      },
-                      "docTransformerConfigFile": {
-                        "type": "string",
-                        "description": "Path to a JSON file containing document transformer configuration. The file is read from the container filesystem."
                       },
                       "documentsPerBulkRequest": {
                         "type": "number",
@@ -2803,10 +2779,6 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "type": "string",
                     "description": "Base64-encoded request transformer configuration. Alternative to transformerConfig for configurations containing special characters."
                   },
-                  "transformerConfigFile": {
-                    "type": "string",
-                    "description": "Path to a JSON file containing request transformer configuration. The file is read from the container filesystem."
-                  },
                   "tupleTransformerConfig": {
                     "type": "string",
                     "description": "Inline tuple transformer configuration as a JSON string. Tuple transformers operate on request-response pairs for stateful transformations."
@@ -2814,10 +2786,6 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "tupleTransformerConfigBase64": {
                     "type": "string",
                     "description": "Base64-encoded tuple transformer configuration."
-                  },
-                  "tupleTransformerConfigFile": {
-                    "type": "string",
-                    "description": "Path to a JSON file containing tuple transformer configuration."
                   },
                   "userAgent": {
                     "type": "string",

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -1996,7 +1996,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "otelCollectorEndpoint": {
                         "type": "string",
                         "default": "http://otel-collector:4317",
-                        "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector for metadata migration metrics."
+                        "description": "URL for the OpenTelemetry Collector for metadata migration metrics."
                       },
                       "output": {
                         "anyOf": [
@@ -2154,7 +2154,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "otelCollectorEndpoint": {
                         "type": "string",
                         "default": "http://otel-collector:4317",
-                        "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."
+                        "description": "URL for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."
                       }
                     },
                     "description": "Configuration for backfilling documents from the snapshot to the target using Reindex From Snapshot. Omit to skip document backfill."
@@ -2289,7 +2289,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "otelCollectorEndpoint": {
                     "type": "string",
                     "default": "http://otel-collector:4317",
-                    "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector. The proxy sends metrics and traces to this endpoint."
+                    "description": "URL for the OpenTelemetry Collector to which the proxy sends metrics and traces."
                   },
                   "setHeader": {
                     "type": "array",
@@ -2625,7 +2625,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "otelCollectorEndpoint": {
                     "type": "string",
                     "default": "http://otel-collector:4317",
-                    "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector. The replayer sends metrics and traces to this endpoint for monitoring replay progress."
+                    "description": "URL for the OpenTelemetry Collector to which the replayer sends metrics and traces."
                   },
                   "quiescentPeriodMs": {
                     "type": "number",

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -42,7 +42,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "type"
-                          ]
+                          ],
+                          "description": "Use ephemeral (emptyDir) storage. Data is lost when pods restart. Suitable for development and testing."
                         },
                         {
                           "type": "object",
@@ -54,13 +55,15 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               ]
                             },
                             "size": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Size of the PersistentVolumeClaim (e.g. '10Gi', '100Gi')."
                             }
                           },
                           "required": [
                             "type",
                             "size"
-                          ]
+                          ],
+                          "description": "Use persistent storage backed by a PersistentVolumeClaim. Required for production workloads."
                         }
                       ],
                       "default": {
@@ -117,7 +120,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     "kafkaTopic": {
                       "type": "string",
                       "default": "",
-                      "description": "Empty defaults to the name of the target label"
+                      "description": "Kafka topic name for captured traffic. If empty, defaults to the name of the associated proxy or target label."
                     },
                     "label": {
                       "type": "string"
@@ -160,24 +163,24 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "cpu": {
                               "type": "string",
                               "pattern": "^[0-9]+m$",
-                              "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                              "description": "CPU allocation for the container in Kubernetes millicores."
                             },
                             "memory": {
                               "type": "string",
                               "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                              "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                              "description": "Memory allocation for the container."
                             },
                             "ephemeral-storage": {
                               "type": "string",
                               "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                              "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                              "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                             }
                           },
                           "required": [
                             "cpu",
                             "memory"
                           ],
-                          "description": "Resource upper bound for a container"
+                          "description": "Maximum resource limits for the container. The container will be terminated if it exceeds these limits."
                         },
                         "requests": {
                           "type": "object",
@@ -185,24 +188,24 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "cpu": {
                               "type": "string",
                               "pattern": "^[0-9]+m$",
-                              "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                              "description": "CPU allocation for the container in Kubernetes millicores."
                             },
                             "memory": {
                               "type": "string",
                               "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                              "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                              "description": "Memory allocation for the container."
                             },
                             "ephemeral-storage": {
                               "type": "string",
                               "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                              "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                              "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                             }
                           },
                           "required": [
                             "cpu",
                             "memory"
                           ],
-                          "description": "Resource lower bound for a container"
+                          "description": "Minimum guaranteed resources for the container. Used by the Kubernetes scheduler for pod placement."
                         }
                       },
                       "default": {
@@ -219,7 +222,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                         "limits",
                         "requests"
                       ],
-                      "description": "Resource limits and requests for proxy container."
+                      "description": "Kubernetes resource limits and requests for the capture proxy container. Defaults to 3500m CPU and 3500Mi memory for both limits and requests (Guaranteed QoS)."
                     },
                     "otelCollectorEndpoint": {
                       "type": "string",
@@ -229,7 +232,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "description": "List of static headers to add to proxied requests, each in 'Header-Name: value' format."
                     },
                     "destinationConnectionPoolSize": {
                       "type": "number",
@@ -245,7 +249,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                       "default": "HttpCaptureProxyProducer"
                     },
                     "listenPort": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "TCP port the capture proxy listens on for incoming HTTP(S) traffic. This port is exposed via the Kubernetes Service and used to construct the proxy endpoint URL."
                     },
                     "maxTrafficBufferSize": {
                       "type": "number",
@@ -261,7 +266,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     },
                     "sslConfigFile": {
                       "type": "string",
-                      "description": "Legacy: YAML config for OpenSearch security SSL. Prefer tls config for K8s deployments."
+                      "description": "Path to a YAML file with OpenSearch security SSL configuration (plugins.security.ssl.http.* keys). Legacy option for non-Kubernetes deployments. For Kubernetes, prefer the 'tls' configuration instead."
                     },
                     "tls": {
                       "oneOf": [
@@ -272,14 +277,15 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "type": "string",
                               "enum": [
                                 "certManager"
-                              ]
+                              ],
+                              "description": "Use cert-manager to automatically provision and renew a TLS certificate."
                             },
                             "issuerRef": {
                               "type": "object",
                               "properties": {
                                 "name": {
                                   "type": "string",
-                                  "description": "Name of the cert-manager Issuer or ClusterIssuer."
+                                  "description": "Name of the cert-manager Issuer or ClusterIssuer resource that will sign the certificate."
                                 },
                                 "kind": {
                                   "type": "string",
@@ -288,20 +294,22 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                                     "ClusterIssuer"
                                   ],
                                   "default": "ClusterIssuer",
-                                  "description": "Kind of the issuer resource."
+                                  "description": "Kind of the cert-manager issuer resource. 'ClusterIssuer' is cluster-scoped; 'Issuer' is namespace-scoped."
                                 },
                                 "group": {
                                   "type": "string",
                                   "default": "cert-manager.io",
-                                  "description": "API group of the issuer. Use 'awspca.cert-manager.io' for AWS PCA issuers."
+                                  "description": "API group of the issuer. Use 'cert-manager.io' for standard issuers or 'awspca.cert-manager.io' for AWS Private CA issuers."
                                 }
                               },
                               "required": [
                                 "name"
-                              ]
+                              ],
+                              "description": "Reference to a cert-manager issuer that will sign TLS certificates for the proxy."
                             },
                             "commonName": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Optional common name (CN) for the TLS certificate subject."
                             },
                             "dnsNames": {
                               "type": "array",
@@ -309,17 +317,17 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                                 "type": "string"
                               },
                               "minItems": 1,
-                              "description": "DNS names for the certificate. Must include the proxy's service DNS name."
+                              "description": "DNS Subject Alternative Names for the certificate. Must include the proxy's Kubernetes service DNS name (e.g. 'my-proxy.default.svc.cluster.local')."
                             },
                             "duration": {
                               "type": "string",
                               "default": "2160h",
-                              "description": "Requested certificate validity duration (default: 90 days)."
+                              "description": "Requested certificate validity duration in Go duration format. Default is '2160h' (90 days)."
                             },
                             "renewBefore": {
                               "type": "string",
                               "default": "360h",
-                              "description": "How long before expiry to renew (default: 15 days)."
+                              "description": "How long before certificate expiry to trigger renewal. Default is '360h' (15 days)."
                             }
                           },
                           "required": [
@@ -327,7 +335,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "issuerRef",
                             "dnsNames"
                           ],
-                          "description": "Use cert-manager to provision a TLS certificate for the proxy."
+                          "description": "Provision a TLS certificate via cert-manager. A Certificate resource is created and the resulting secret is mounted into the proxy pod."
                         },
                         {
                           "type": "object",
@@ -336,21 +344,22 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "type": "string",
                               "enum": [
                                 "existingSecret"
-                              ]
+                              ],
+                              "description": "Use a pre-existing Kubernetes TLS secret."
                             },
                             "secretName": {
                               "type": "string",
-                              "description": "Name of an existing K8s TLS secret with tls.crt and tls.key."
+                              "description": "Name of an existing Kubernetes TLS secret containing 'tls.crt' and 'tls.key' entries. The secret is mounted into the proxy pod at /etc/proxy-tls/."
                             }
                           },
                           "required": [
                             "mode",
                             "secretName"
                           ],
-                          "description": "Use a pre-existing K8s TLS secret."
+                          "description": "Use a pre-existing Kubernetes TLS secret for proxy HTTPS termination."
                         }
                       ],
-                      "description": "TLS certificate configuration for the proxy. Mutually exclusive with sslConfigFile."
+                      "description": "TLS certificate configuration for HTTPS termination at the proxy. When configured, the proxy serves HTTPS and the TLS secret is mounted at /etc/proxy-tls/. Mutually exclusive with sslConfigFile."
                     },
                     "enableMSKAuth": {
                       "type": "boolean",
@@ -435,7 +444,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                         "properties": {
                           "awsRegion": {
                             "type": "string",
-                            "description": "The AWS region that the bucket reside in (us-east-2, etc)"
+                            "description": "AWS region where the S3 bucket resides (e.g. 'us-east-2'). Used for S3 client configuration and snapshot repository registration."
                           },
                           "endpoint": {
                             "type": "string",
@@ -445,7 +454,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           "s3RepoPathUri": {
                             "type": "string",
                             "pattern": "^s3:\\\\/\\\\/[a-z0-9][a-z0-9.-]{1,61}[a-z0-9](\\\\/[a-zA-Z0-9!\\\\-_.*'()/]*)?$",
-                            "description": "s3://BUCKETNAME/PATH"
+                            "description": "S3 URI for the snapshot repository in the format 's3://BUCKET_NAME/OPTIONAL_PATH'. The bucket must already exist and be accessible from the source cluster."
                           },
                           "s3RoleArn": {
                             "type": "string",
@@ -513,7 +522,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "properties": {
                                 "secretName": {
                                   "type": "string",
-                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                  "description": "Name of a Kubernetes Secret containing 'username' and 'password' keys for HTTP Basic authentication."
                                 }
                               },
                               "required": [
@@ -523,7 +533,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "basic"
-                          ]
+                          ],
+                          "description": "HTTP Basic authentication using credentials from a Kubernetes Secret."
                         },
                         {
                           "type": "object",
@@ -532,11 +543,13 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "type": "object",
                               "properties": {
                                 "region": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "AWS region for SigV4 request signing (e.g. 'us-east-1')."
                                 },
                                 "service": {
                                   "type": "string",
-                                  "default": "es"
+                                  "default": "es",
+                                  "description": "AWS service name for SigV4 signing. Use 'es' for Amazon OpenSearch Service or 'aoss' for OpenSearch Serverless."
                                 }
                               },
                               "required": [
@@ -546,7 +559,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "sigv4"
-                          ]
+                          ],
+                          "description": "AWS SigV4 request signing authentication. Uses the pod's IAM role credentials."
                         },
                         {
                           "type": "object",
@@ -555,10 +569,12 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "type": "object",
                               "properties": {
                                 "caCert": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "PEM-encoded CA certificate or path to CA certificate file for verifying the server's TLS certificate."
                                 },
                                 "clientSecretName": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "Name of a Kubernetes TLS Secret containing the client certificate and private key for mutual TLS authentication."
                                 }
                               },
                               "required": [
@@ -569,13 +585,16 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "mtls"
-                          ]
+                          ],
+                          "description": "Mutual TLS (mTLS) authentication using client certificates."
                         }
-                      ]
+                      ],
+                      "description": "Authentication configuration for connecting to the cluster. Supports HTTP Basic (Kubernetes Secret), AWS SigV4, or mutual TLS."
                     },
                     "version": {
                       "type": "string",
-                      "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
+                      "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$",
+                      "description": "Version of the source cluster in '<ENGINE> <MAJOR>.<MINOR>.<PATCH>' format (e.g. 'ES 7.10.2', 'OS 1.3.0'). Required for compatibility checks and migration strategy selection."
                     },
                     "label": {
                       "type": "string"
@@ -764,7 +783,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           "useTargetClusterForWorkCoordination": {
                             "type": "boolean",
                             "default": false,
-                            "description": "When true, uses the target OpenSearch cluster for RFS work coordination. When false, a dedicated single-node OpenSearch coordinator cluster is deployed and managed for the lifetime of the migration, then torn down on completion."
+                            "description": "When true, uses the target OpenSearch cluster for RFS work coordination (lease management and shard assignment). When false (default), a dedicated single-node OpenSearch coordinator cluster is automatically deployed, used for the lifetime of the migration, then torn down on completion. Using a dedicated coordinator avoids adding coordination overhead to the target cluster."
                           },
                           "resources": {
                             "type": "object",
@@ -776,24 +795,24 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                                   "cpu": {
                                     "type": "string",
                                     "pattern": "^[0-9]+m$",
-                                    "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                                    "description": "CPU allocation for the container in Kubernetes millicores."
                                   },
                                   "memory": {
                                     "type": "string",
                                     "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                                    "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                                    "description": "Memory allocation for the container."
                                   },
                                   "ephemeral-storage": {
                                     "type": "string",
                                     "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                                    "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                                    "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                                   }
                                 },
                                 "required": [
                                   "cpu",
                                   "memory"
                                 ],
-                                "description": "Resource upper bound for a container"
+                                "description": "Maximum resource limits for the container. The container will be terminated if it exceeds these limits."
                               },
                               "requests": {
                                 "type": "object",
@@ -801,31 +820,31 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                                   "cpu": {
                                     "type": "string",
                                     "pattern": "^[0-9]+m$",
-                                    "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                                    "description": "CPU allocation for the container in Kubernetes millicores."
                                   },
                                   "memory": {
                                     "type": "string",
                                     "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                                    "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                                    "description": "Memory allocation for the container."
                                   },
                                   "ephemeral-storage": {
                                     "type": "string",
                                     "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                                    "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                                    "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                                   }
                                 },
                                 "required": [
                                   "cpu",
                                   "memory"
                                 ],
-                                "description": "Resource lower bound for a container"
+                                "description": "Minimum guaranteed resources for the container. Used by the Kubernetes scheduler for pod placement."
                               }
                             },
                             "required": [
                               "limits",
                               "requests"
                             ],
-                            "description": "Resource limits and requests for RFS container"
+                            "description": "Kubernetes resource limits and requests for the RFS container. Defaults to 3300m CPU and 7000Mi memory. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."
                           },
                           "indexAllowlist": {
                             "type": "array",
@@ -836,8 +855,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "allowLooseVersionMatching": {
                             "type": "boolean",
-                            "default": true,
-                            "description": ""
+                            "default": true
                           },
                           "docTransformerConfigBase64": {
                             "type": "string",
@@ -883,7 +901,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                   "properties": {
                     "endpoint": {
                       "type": "string",
-                      "pattern": "^https?:\\\\/\\\\/[^:\\\\/\\\\s]+(?::(?:[1-9]\\\\d{0,3}|[1-5]\\\\d{4}|6[0-4]\\\\d{3}|65[0-4]\\\\d{2}|655[0-2]\\\\d|6553[0-5]))?(?:\\\\/)?$"
+                      "pattern": "^https?:\\\\/\\\\/[^:\\\\/\\\\s]+(?::(?:[1-9]\\\\d{0,3}|[1-5]\\\\d{4}|6[0-4]\\\\d{3}|65[0-4]\\\\d{2}|655[0-2]\\\\d|6553[0-5]))?(?:\\\\/)?$",
+                      "description": "HTTP(S) endpoint URL for the target cluster (e.g. 'https://target-cluster:9200/'). Required for target clusters."
                     },
                     "allowInsecure": {
                       "type": "boolean",
@@ -899,7 +918,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "properties": {
                                 "secretName": {
                                   "type": "string",
-                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                  "description": "Name of a Kubernetes Secret containing 'username' and 'password' keys for HTTP Basic authentication."
                                 }
                               },
                               "required": [
@@ -909,7 +929,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "basic"
-                          ]
+                          ],
+                          "description": "HTTP Basic authentication using credentials from a Kubernetes Secret."
                         },
                         {
                           "type": "object",
@@ -918,11 +939,13 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "type": "object",
                               "properties": {
                                 "region": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "AWS region for SigV4 request signing (e.g. 'us-east-1')."
                                 },
                                 "service": {
                                   "type": "string",
-                                  "default": "es"
+                                  "default": "es",
+                                  "description": "AWS service name for SigV4 signing. Use 'es' for Amazon OpenSearch Service or 'aoss' for OpenSearch Serverless."
                                 }
                               },
                               "required": [
@@ -932,7 +955,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "sigv4"
-                          ]
+                          ],
+                          "description": "AWS SigV4 request signing authentication. Uses the pod's IAM role credentials."
                         },
                         {
                           "type": "object",
@@ -941,10 +965,12 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "type": "object",
                               "properties": {
                                 "caCert": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "PEM-encoded CA certificate or path to CA certificate file for verifying the server's TLS certificate."
                                 },
                                 "clientSecretName": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "Name of a Kubernetes TLS Secret containing the client certificate and private key for mutual TLS authentication."
                                 }
                               },
                               "required": [
@@ -955,9 +981,11 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "mtls"
-                          ]
+                          ],
+                          "description": "Mutual TLS (mTLS) authentication using client certificates."
                         }
-                      ]
+                      ],
+                      "description": "Authentication configuration for connecting to the cluster. Supports HTTP Basic (Kubernetes Secret), AWS SigV4, or mutual TLS."
                     },
                     "label": {
                       "type": "string",
@@ -980,7 +1008,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                       "properties": {
                         "awsRegion": {
                           "type": "string",
-                          "description": "The AWS region that the bucket reside in (us-east-2, etc)"
+                          "description": "AWS region where the S3 bucket resides (e.g. 'us-east-2'). Used for S3 client configuration and snapshot repository registration."
                         },
                         "endpoint": {
                           "type": "string",
@@ -990,7 +1018,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                         "s3RepoPathUri": {
                           "type": "string",
                           "pattern": "^s3:\\\\/\\\\/[a-z0-9][a-z0-9.-]{1,61}[a-z0-9](\\\\/[a-zA-Z0-9!\\\\-_.*'()/]*)?$",
-                          "description": "s3://BUCKETNAME/PATH"
+                          "description": "S3 URI for the snapshot repository in the format 's3://BUCKET_NAME/OPTIONAL_PATH'. The bucket must already exist and be accessible from the source cluster."
                         },
                         "s3RoleArn": {
                           "type": "string",
@@ -1041,16 +1069,19 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     "type": "object",
                     "properties": {
                       "source": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Name of the source cluster. Must match a key in sourceClusters."
                       },
                       "snapshot": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Name of the snapshot. Must match a key in the source cluster's snapshotInfo.snapshots."
                       }
                     },
                     "required": [
                       "source",
                       "snapshot"
-                    ]
+                    ],
+                    "description": "Reference to a specific snapshot from a specific source cluster, used to express dependencies."
                   }
                 },
                 "fromProxy": {
@@ -1073,7 +1104,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     "kafkaTopic": {
                       "type": "string",
                       "default": "",
-                      "description": "Empty defaults to the name of the target label"
+                      "description": "Kafka topic name for captured traffic. If empty, defaults to the name of the associated proxy or target label."
                     },
                     "label": {
                       "type": "string"
@@ -1109,24 +1140,24 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "cpu": {
                               "type": "string",
                               "pattern": "^[0-9]+m$",
-                              "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                              "description": "CPU allocation for the container in Kubernetes millicores."
                             },
                             "memory": {
                               "type": "string",
                               "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                              "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                              "description": "Memory allocation for the container."
                             },
                             "ephemeral-storage": {
                               "type": "string",
                               "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                              "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                              "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                             }
                           },
                           "required": [
                             "cpu",
                             "memory"
                           ],
-                          "description": "Resource upper bound for a container"
+                          "description": "Maximum resource limits for the container. The container will be terminated if it exceeds these limits."
                         },
                         "requests": {
                           "type": "object",
@@ -1134,31 +1165,31 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "cpu": {
                               "type": "string",
                               "pattern": "^[0-9]+m$",
-                              "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                              "description": "CPU allocation for the container in Kubernetes millicores."
                             },
                             "memory": {
                               "type": "string",
                               "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                              "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                              "description": "Memory allocation for the container."
                             },
                             "ephemeral-storage": {
                               "type": "string",
                               "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                              "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                              "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                             }
                           },
                           "required": [
                             "cpu",
                             "memory"
                           ],
-                          "description": "Resource lower bound for a container"
+                          "description": "Minimum guaranteed resources for the container. Used by the Kubernetes scheduler for pod placement."
                         }
                       },
                       "required": [
                         "limits",
                         "requests"
                       ],
-                      "description": "Resource limits and requests for replayer container."
+                      "description": "Kubernetes resource limits and requests for the replayer container. Defaults to 3500m CPU and 3500Mi memory (Guaranteed QoS)."
                     },
                     "kafkaTrafficEnableMSKAuth": {
                       "type": "boolean",
@@ -1166,7 +1197,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     },
                     "kafkaTrafficPropertyFile": {
                       "type": "string",
-                      "description": "File path for Kafka properties file for additional or overridden Kafka properties."
+                      "description": "Path to a Java properties file with additional or overridden Kafka consumer configuration. Mounted into the replayer container."
                     },
                     "lookaheadTimeSeconds": {
                       "type": "number",
@@ -1206,19 +1237,19 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     },
                     "transformerConfig": {
                       "type": "string",
-                      "description": "Request transformer configuration as a string or JSON."
+                      "description": "Inline request transformer configuration as a JSON string. Defines transformations applied to each request before replaying to the target."
                     },
                     "transformerConfigEncoded": {
                       "type": "string",
-                      "description": "Base64-encoded request transformer configuration."
+                      "description": "Base64-encoded request transformer configuration. Alternative to transformerConfig for configurations containing special characters."
                     },
                     "transformerConfigFile": {
                       "type": "string",
-                      "description": "Path to the JSON configuration file for request transformers."
+                      "description": "Path to a JSON file containing request transformer configuration. The file is read from the container filesystem."
                     },
                     "tupleTransformerConfig": {
                       "type": "string",
-                      "description": "Tuple transformer configuration as a string or JSON."
+                      "description": "Inline tuple transformer configuration as a JSON string. Tuple transformers operate on request-response pairs for stateful transformations."
                     },
                     "tupleTransformerConfigBase64": {
                       "type": "string",
@@ -1226,11 +1257,11 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     },
                     "tupleTransformerConfigFile": {
                       "type": "string",
-                      "description": "Path to the JSON configuration file for tuple transformers."
+                      "description": "Path to a JSON file containing tuple transformer configuration."
                     },
                     "userAgent": {
                       "type": "string",
-                      "description": "String appended to the user-agent header for requests to the target cluster."
+                      "description": "String appended to the User-Agent header on all replayed requests to the target cluster. Useful for identifying replayed traffic in target cluster logs."
                     }
                   }
                 },
@@ -1239,7 +1270,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                   "properties": {
                     "endpoint": {
                       "type": "string",
-                      "pattern": "^https?:\\\\/\\\\/[^:\\\\/\\\\s]+(?::(?:[1-9]\\\\d{0,3}|[1-5]\\\\d{4}|6[0-4]\\\\d{3}|65[0-4]\\\\d{2}|655[0-2]\\\\d|6553[0-5]))?(?:\\\\/)?$"
+                      "pattern": "^https?:\\\\/\\\\/[^:\\\\/\\\\s]+(?::(?:[1-9]\\\\d{0,3}|[1-5]\\\\d{4}|6[0-4]\\\\d{3}|65[0-4]\\\\d{2}|655[0-2]\\\\d|6553[0-5]))?(?:\\\\/)?$",
+                      "description": "HTTP(S) endpoint URL for the target cluster (e.g. 'https://target-cluster:9200/'). Required for target clusters."
                     },
                     "allowInsecure": {
                       "type": "boolean",
@@ -1255,7 +1287,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "properties": {
                                 "secretName": {
                                   "type": "string",
-                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                  "description": "Name of a Kubernetes Secret containing 'username' and 'password' keys for HTTP Basic authentication."
                                 }
                               },
                               "required": [
@@ -1265,7 +1298,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "basic"
-                          ]
+                          ],
+                          "description": "HTTP Basic authentication using credentials from a Kubernetes Secret."
                         },
                         {
                           "type": "object",
@@ -1274,11 +1308,13 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "type": "object",
                               "properties": {
                                 "region": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "AWS region for SigV4 request signing (e.g. 'us-east-1')."
                                 },
                                 "service": {
                                   "type": "string",
-                                  "default": "es"
+                                  "default": "es",
+                                  "description": "AWS service name for SigV4 signing. Use 'es' for Amazon OpenSearch Service or 'aoss' for OpenSearch Serverless."
                                 }
                               },
                               "required": [
@@ -1288,7 +1324,8 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "sigv4"
-                          ]
+                          ],
+                          "description": "AWS SigV4 request signing authentication. Uses the pod's IAM role credentials."
                         },
                         {
                           "type": "object",
@@ -1297,10 +1334,12 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "type": "object",
                               "properties": {
                                 "caCert": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "PEM-encoded CA certificate or path to CA certificate file for verifying the server's TLS certificate."
                                 },
                                 "clientSecretName": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "Name of a Kubernetes TLS Secret containing the client certificate and private key for mutual TLS authentication."
                                 }
                               },
                               "required": [
@@ -1311,9 +1350,11 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "required": [
                             "mtls"
-                          ]
+                          ],
+                          "description": "Mutual TLS (mTLS) authentication using client certificates."
                         }
-                      ]
+                      ],
+                      "description": "Authentication configuration for connecting to the cluster. Supports HTTP Basic (Kubernetes Secret), AWS SigV4, or mutual TLS."
                     },
                     "label": {
                       "type": "string",
@@ -1353,7 +1394,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
   "properties": {
     "skipApprovals": {
       "type": "boolean",
-      "default": false
+      "default": false,
+      "description": "Global flag to skip all manual approval gates across the entire migration. When true, overrides all per-component skipApproval settings."
     },
     "kafkaClusterConfiguration": {
       "type": "object",
@@ -1368,7 +1410,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "replicas": {
                     "type": "integer",
                     "minimum": 1,
-                    "default": 1
+                    "default": 1,
+                    "description": "Number of Kafka broker replicas in the Strimzi Kafka cluster. Increase for higher availability and throughput."
                   },
                   "storage": {
                     "oneOf": [
@@ -1384,7 +1427,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         },
                         "required": [
                           "type"
-                        ]
+                        ],
+                        "description": "Use ephemeral (emptyDir) storage. Data is lost when pods restart. Suitable for development and testing."
                       },
                       {
                         "type": "object",
@@ -1396,35 +1440,42 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                             ]
                           },
                           "size": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Size of the PersistentVolumeClaim (e.g. '10Gi', '100Gi')."
                           }
                         },
                         "required": [
                           "type",
                           "size"
-                        ]
+                        ],
+                        "description": "Use persistent storage backed by a PersistentVolumeClaim. Required for production workloads."
                       }
                     ],
                     "default": {
                       "type": "ephemeral"
-                    }
+                    },
+                    "description": "Storage configuration for Kafka broker data."
                   },
                   "partitions": {
                     "type": "integer",
                     "minimum": 1,
-                    "default": 1
+                    "default": 1,
+                    "description": "Default number of partitions for auto-created Kafka topics. More partitions enable higher parallelism for consumers."
                   },
                   "topicReplicas": {
                     "type": "integer",
                     "minimum": 1,
-                    "default": 1
+                    "default": 1,
+                    "description": "Replication factor for auto-created Kafka topics. Must not exceed the number of broker replicas. Higher values improve durability."
                   }
-                }
+                },
+                "description": "Configuration for auto-creating a Strimzi Kafka cluster. Used when no existing Kafka cluster is provided."
               }
             },
             "required": [
               "autoCreate"
-            ]
+            ],
+            "description": "Auto-create a new Strimzi Kafka cluster with the specified configuration. The cluster bootstrap service is available at '<clusterName>-kafka-bootstrap:9092'."
           },
           {
             "type": "object",
@@ -1434,7 +1485,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                 "properties": {
                   "enableMSKAuth": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Enable SASL/IAM authentication for Amazon MSK. When true, configures the Kafka client with the required SASL properties for IAM-based authentication."
                   },
                   "kafkaConnection": {
                     "type": "string",
@@ -1443,21 +1495,25 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "kafkaTopic": {
                     "type": "string",
                     "default": "",
-                    "description": "Empty defaults to the name of the target label"
+                    "description": "Kafka topic name for captured traffic. If empty, defaults to the name of the associated proxy or target label."
                   }
                 },
                 "required": [
                   "kafkaConnection"
-                ]
+                ],
+                "description": "Client connection configuration for an existing Kafka cluster."
               }
             },
             "required": [
               "existing"
-            ]
+            ],
+            "description": "Use an existing Kafka cluster by providing connection details."
           }
-        ]
+        ],
+        "description": "Kafka cluster configuration: either auto-create a new Strimzi cluster or connect to an existing one."
       },
-      "default": {}
+      "default": {},
+      "description": "Kafka cluster configurations. If empty and traffic capture is configured, a default ephemeral Kafka cluster is auto-created for each referenced cluster name."
     },
     "sourceClusters": {
       "type": "object",
@@ -1467,11 +1523,13 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
           "endpoint": {
             "type": "string",
             "pattern": "^(?:https?:\\\\/\\\\/[^:\\\\/\\\\s]+(?::(?:[1-9]\\\\d{0,3}|[1-5]\\\\d{4}|6[0-4]\\\\d{3}|65[0-4]\\\\d{2}|655[0-2]\\\\d|6553[0-5]))?(?:\\\\/)?)?$",
-            "default": ""
+            "default": "",
+            "description": "HTTP(S) endpoint URL for the cluster (e.g. 'https://my-cluster:9200/'). Leave empty if the cluster is not directly accessible or will be accessed through a proxy."
           },
           "allowInsecure": {
             "type": "boolean",
-            "default": false
+            "default": false,
+            "description": "When true, disables TLS certificate verification when connecting to the cluster. Use only for development or self-signed certificates."
           },
           "authConfig": {
             "anyOf": [
@@ -1483,7 +1541,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "properties": {
                       "secretName": {
                         "type": "string",
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                        "description": "Name of a Kubernetes Secret containing 'username' and 'password' keys for HTTP Basic authentication."
                       }
                     },
                     "required": [
@@ -1493,7 +1552,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                 },
                 "required": [
                   "basic"
-                ]
+                ],
+                "description": "HTTP Basic authentication using credentials from a Kubernetes Secret."
               },
               {
                 "type": "object",
@@ -1502,11 +1562,13 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "type": "object",
                     "properties": {
                       "region": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "AWS region for SigV4 request signing (e.g. 'us-east-1')."
                       },
                       "service": {
                         "type": "string",
-                        "default": "es"
+                        "default": "es",
+                        "description": "AWS service name for SigV4 signing. Use 'es' for Amazon OpenSearch Service or 'aoss' for OpenSearch Serverless."
                       }
                     },
                     "required": [
@@ -1516,7 +1578,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                 },
                 "required": [
                   "sigv4"
-                ]
+                ],
+                "description": "AWS SigV4 request signing authentication. Uses the pod's IAM role credentials."
               },
               {
                 "type": "object",
@@ -1525,10 +1588,12 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "type": "object",
                     "properties": {
                       "caCert": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "PEM-encoded CA certificate or path to CA certificate file for verifying the server's TLS certificate."
                       },
                       "clientSecretName": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Name of a Kubernetes TLS Secret containing the client certificate and private key for mutual TLS authentication."
                       }
                     },
                     "required": [
@@ -1539,17 +1604,21 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                 },
                 "required": [
                   "mtls"
-                ]
+                ],
+                "description": "Mutual TLS (mTLS) authentication using client certificates."
               }
-            ]
+            ],
+            "description": "Authentication configuration for connecting to the cluster. Supports HTTP Basic (Kubernetes Secret), AWS SigV4, or mutual TLS."
           },
           "version": {
             "type": "string",
-            "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
+            "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$",
+            "description": "Version of the source cluster in '<ENGINE> <MAJOR>.<MINOR>.<PATCH>' format (e.g. 'ES 7.10.2', 'OS 1.3.0'). Required for compatibility checks and migration strategy selection."
           },
           "enabled": {
             "type": "boolean",
-            "default": true
+            "default": true,
+            "description": "When false, this source cluster is excluded from the migration. Useful for temporarily disabling a source without removing its configuration."
           },
           "snapshotInfo": {
             "type": "object",
@@ -1561,32 +1630,33 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "properties": {
                     "awsRegion": {
                       "type": "string",
-                      "description": "The AWS region that the bucket reside in (us-east-2, etc)"
+                      "description": "AWS region where the S3 bucket resides (e.g. 'us-east-2'). Used for S3 client configuration and snapshot repository registration."
                     },
                     "endpoint": {
                       "type": "string",
                       "pattern": "(?:^(http|localstack)s?:\\\\/\\\\/[^/]*\\\\/?$)?",
                       "default": "",
-                      "description": "Override the default S3 endpoint for clients to connect to. Necessary for testing, when S3 isn't used, or when it's only accessible via another endpoint"
+                      "description": "Override the default S3 endpoint URL. Supports http://, https://, localstack://, and localstacks:// schemes. LocalStack endpoints are automatically resolved to IP addresses during config transformation. Leave empty to use the default AWS S3 endpoint."
                     },
                     "s3RepoPathUri": {
                       "type": "string",
                       "pattern": "^s3:\\\\/\\\\/[a-z0-9][a-z0-9.-]{1,61}[a-z0-9](\\\\/[a-zA-Z0-9!\\\\-_.*'()/]*)?$",
-                      "description": "s3://BUCKETNAME/PATH"
+                      "description": "S3 URI for the snapshot repository in the format 's3://BUCKET_NAME/OPTIONAL_PATH'. The bucket must already exist and be accessible from the source cluster."
                     },
                     "s3RoleArn": {
                       "type": "string",
                       "pattern": "^(arn:aws:iam::\\\\d{12}:(user|role|group|policy)\\\\/[a-zA-Z0-9+=,.@_-]+)?$",
                       "default": "",
-                      "description": "IAM role ARN to assume when accessing S3 for snapshot operations"
+                      "description": "IAM role ARN to assume when accessing S3 for snapshot operations. Leave empty to use the default credentials of the migration infrastructure."
                     }
                   },
                   "required": [
                     "awsRegion",
                     "s3RepoPathUri"
-                  ]
+                  ],
+                  "description": "Configuration for an S3-backed snapshot repository used by the source cluster."
                 },
-                "description": "Keys are the repository names that are managed by the source cluster"
+                "description": "S3 snapshot repositories registered with the source cluster."
               },
               "snapshots": {
                 "type": "object",
@@ -1599,12 +1669,14 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "type": "object",
                           "properties": {
                             "externallyManagedSnapshotName": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Name of a pre-existing snapshot in the source cluster's repository. The workflow will use this snapshot directly without creating a new one."
                             }
                           },
                           "required": [
                             "externallyManagedSnapshotName"
-                          ]
+                          ],
+                          "description": "Reference to a snapshot that was created outside of this migration workflow."
                         },
                         {
                           "type": "object",
@@ -1614,28 +1686,34 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                               "properties": {
                                 "snapshotPrefix": {
                                   "type": "string",
-                                  "default": ""
+                                  "default": "",
+                                  "description": "Prefix for auto-generated snapshot names. The final snapshot name is constructed as '<sourceLabel>_<snapshotPrefix>_<uniqueRunNonce>'. If empty, the snapshot record key name is used as the prefix."
                                 },
                                 "jvmArgs": {
                                   "type": "string",
-                                  "default": ""
+                                  "default": "",
+                                  "description": "Additional JVM arguments passed to the CreateSnapshot process via JDK_JAVA_OPTIONS (e.g. '-Xmx2g')."
                                 },
                                 "loggingConfigurationOverrideConfigMap": {
                                   "type": "string",
-                                  "default": ""
+                                  "default": "",
+                                  "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the snapshot creation process. Leave empty for defaults."
                                 },
                                 "indexAllowlist": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "default": []
+                                  "default": [],
+                                  "description": "List of index name patterns to include in the snapshot. An empty list means all indices are included."
                                 },
                                 "maxSnapshotRateMbPerNode": {
                                   "type": "number",
-                                  "default": 0
+                                  "default": 0,
+                                  "description": "Maximum snapshot throughput in MB/s per data node. 0 means no rate limiting. Use to reduce I/O impact on the source cluster during snapshot creation."
                                 }
-                              }
+                              },
+                              "description": "Configuration for creating a new snapshot of the source cluster."
                             },
                             "requiredForCompleteMigration": {
                               "anyOf": [
@@ -1646,7 +1724,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "description": "List of target cluster names that require this snapshot for a complete migration."
                                     }
                                   },
                                   "required": [
@@ -1657,35 +1736,43 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                                   "type": "boolean",
                                   "default": true
                                 }
-                              ]
+                              ],
+                              "description": "Whether this snapshot is required for migration completeness. Can be true/false or specify specific target clusters."
                             }
                           },
                           "required": [
                             "createSnapshotConfig"
-                          ]
+                          ],
+                          "description": "Configuration to create a new snapshot of the source cluster as part of the migration workflow."
                         }
-                      ]
+                      ],
+                      "description": "Snapshot configuration: either an externally managed snapshot name or settings to create a new snapshot."
                     },
                     "repoName": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Name of the S3 snapshot repository. Must match a key in the source cluster's snapshotInfo.repos."
                     }
                   },
                   "required": [
                     "config",
                     "repoName"
-                  ]
-                }
+                  ],
+                  "description": "A snapshot configuration bound to a specific repository."
+                },
+                "description": "Snapshots to use or create for this source cluster."
               }
             },
             "required": [
               "snapshots"
-            ]
+            ],
+            "description": "Snapshot repository and snapshot configurations for this source cluster. Required if any snapshot-based migrations reference this source."
           }
         },
         "required": [
           "version"
         ]
-      }
+      },
+      "description": "Source Elasticsearch or OpenSearch clusters to migrate from."
     },
     "targetClusters": {
       "type": "object",
@@ -1694,11 +1781,13 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
         "properties": {
           "endpoint": {
             "type": "string",
-            "pattern": "^https?:\\\\/\\\\/[^:\\\\/\\\\s]+(?::(?:[1-9]\\\\d{0,3}|[1-5]\\\\d{4}|6[0-4]\\\\d{3}|65[0-4]\\\\d{2}|655[0-2]\\\\d|6553[0-5]))?(?:\\\\/)?$"
+            "pattern": "^https?:\\\\/\\\\/[^:\\\\/\\\\s]+(?::(?:[1-9]\\\\d{0,3}|[1-5]\\\\d{4}|6[0-4]\\\\d{3}|65[0-4]\\\\d{2}|655[0-2]\\\\d|6553[0-5]))?(?:\\\\/)?$",
+            "description": "HTTP(S) endpoint URL for the target cluster (e.g. 'https://target-cluster:9200/'). Required for target clusters."
           },
           "allowInsecure": {
             "type": "boolean",
-            "default": false
+            "default": false,
+            "description": "When true, disables TLS certificate verification when connecting to the cluster. Use only for development or self-signed certificates."
           },
           "authConfig": {
             "anyOf": [
@@ -1710,7 +1799,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "properties": {
                       "secretName": {
                         "type": "string",
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                        "description": "Name of a Kubernetes Secret containing 'username' and 'password' keys for HTTP Basic authentication."
                       }
                     },
                     "required": [
@@ -1720,7 +1810,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                 },
                 "required": [
                   "basic"
-                ]
+                ],
+                "description": "HTTP Basic authentication using credentials from a Kubernetes Secret."
               },
               {
                 "type": "object",
@@ -1729,11 +1820,13 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "type": "object",
                     "properties": {
                       "region": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "AWS region for SigV4 request signing (e.g. 'us-east-1')."
                       },
                       "service": {
                         "type": "string",
-                        "default": "es"
+                        "default": "es",
+                        "description": "AWS service name for SigV4 signing. Use 'es' for Amazon OpenSearch Service or 'aoss' for OpenSearch Serverless."
                       }
                     },
                     "required": [
@@ -1743,7 +1836,8 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                 },
                 "required": [
                   "sigv4"
-                ]
+                ],
+                "description": "AWS SigV4 request signing authentication. Uses the pod's IAM role credentials."
               },
               {
                 "type": "object",
@@ -1752,10 +1846,12 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "type": "object",
                     "properties": {
                       "caCert": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "PEM-encoded CA certificate or path to CA certificate file for verifying the server's TLS certificate."
                       },
                       "clientSecretName": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Name of a Kubernetes TLS Secret containing the client certificate and private key for mutual TLS authentication."
                       }
                     },
                     "required": [
@@ -1766,19 +1862,24 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                 },
                 "required": [
                   "mtls"
-                ]
+                ],
+                "description": "Mutual TLS (mTLS) authentication using client certificates."
               }
-            ]
+            ],
+            "description": "Authentication configuration for connecting to the cluster. Supports HTTP Basic (Kubernetes Secret), AWS SigV4, or mutual TLS."
           },
           "enabled": {
             "type": "boolean",
-            "default": true
+            "default": true,
+            "description": "When false, this target cluster is excluded from the migration. Useful for temporarily disabling a target without removing its configuration."
           }
         },
         "required": [
           "endpoint"
-        ]
-      }
+        ],
+        "description": "Connection configuration for a target OpenSearch cluster. Extends the base cluster config with a required endpoint."
+      },
+      "description": "Target OpenSearch clusters to migrate to."
     },
     "snapshotMigrationConfigs": {
       "type": "array",
@@ -1787,13 +1888,16 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
         "properties": {
           "skipApprovals": {
             "type": "boolean",
-            "default": false
+            "default": false,
+            "description": "When true, skips all manual approval gates for migrations in this configuration block."
           },
           "fromSource": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the source cluster to migrate from. Must match a key in sourceClusters."
           },
           "toTarget": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the target cluster to migrate to. Must match a key in targetClusters."
           },
           "perSnapshotConfig": {
             "type": "object",
@@ -1805,55 +1909,65 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "label": {
                     "type": "string",
                     "pattern": "^[a-zA-Z][a-zA-Z0-9]*",
-                    "default": ""
+                    "default": "",
+                    "description": "Unique label for this migration within its snapshot group. Auto-generated as 'migration-<index>' if not specified. Must start with a letter and contain only alphanumeric characters."
                   },
                   "metadataMigrationConfig": {
                     "type": "object",
                     "properties": {
                       "jvmArgs": {
                         "type": "string",
-                        "default": ""
+                        "default": "",
+                        "description": "Additional JVM arguments passed to the metadata migration process via JDK_JAVA_OPTIONS."
                       },
                       "loggingConfigurationOverrideConfigMap": {
                         "type": "string",
-                        "default": ""
+                        "default": "",
+                        "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the metadata migration process."
                       },
                       "skipEvaluateApproval": {
                         "type": "boolean",
-                        "default": false
+                        "default": false,
+                        "description": "When true, skips the manual approval gate before the metadata evaluation step. The evaluation step analyzes what metadata changes would be applied without making changes."
                       },
                       "skipMigrateApproval": {
                         "type": "boolean",
-                        "default": false
+                        "default": false,
+                        "description": "When true, skips the manual approval gate before the metadata migration step. The migration step applies the evaluated metadata changes to the target cluster."
                       },
                       "componentTemplateAllowlist": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "default": []
+                        "default": [],
+                        "description": "List of component template name patterns to include in the metadata migration. An empty list means all component templates are included."
                       },
                       "indexAllowlist": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "default": []
+                        "default": [],
+                        "description": "List of index name patterns to include in the metadata migration. An empty list means all indices are included."
                       },
                       "indexTemplateAllowlist": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "default": []
+                        "default": [],
+                        "description": "List of index template name patterns to include in the metadata migration. An empty list means all index templates are included."
                       },
                       "allowLooseVersionMatching": {
                         "type": "boolean",
-                        "default": true
+                        "default": true,
+                        "description": "When true, allows metadata migration between clusters with non-exact version compatibility (e.g. ES 7.x to OS 2.x). When false, requires strict version matching."
                       },
                       "clusterAwarenessAttributes": {
                         "type": "number",
-                        "default": 1
+                        "default": 1,
+                        "description": "Number of shard allocation awareness attributes to preserve during metadata migration. Controls how index settings related to cluster topology are handled."
                       },
                       "multiTypeBehavior": {
                         "anyOf": [
@@ -1876,11 +1990,13 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                             ]
                           }
                         ],
-                        "default": "NONE"
+                        "default": "NONE",
+                        "description": "Strategy for handling Elasticsearch multi-type indices (ES 5.x and earlier). 'NONE': fail if multi-type indices are encountered. 'UNION': merge all types into a single mapping. 'SPLIT': create separate indices for each type."
                       },
                       "otelCollectorEndpoint": {
                         "type": "string",
-                        "default": "http://otel-collector:4317"
+                        "default": "http://otel-collector:4317",
+                        "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector for metadata migration metrics."
                       },
                       "output": {
                         "anyOf": [
@@ -1897,37 +2013,44 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                             ]
                           }
                         ],
-                        "default": "HUMAN_READABLE"
+                        "default": "HUMAN_READABLE",
+                        "description": "Output format for the metadata migration evaluation report. 'HUMAN_READABLE' for formatted text, 'JSON' for machine-parseable output."
                       },
                       "transformerConfigBase64": {
                         "type": "string",
-                        "default": ""
+                        "default": "",
+                        "description": "Base64-encoded JSON configuration for metadata transformers. Defines custom transformations applied to index mappings and settings during migration."
                       }
-                    }
+                    },
+                    "description": "Configuration for migrating index metadata (mappings, settings, templates) from the snapshot to the target. Omit to skip metadata migration."
                   },
                   "documentBackfillConfig": {
                     "type": "object",
                     "properties": {
                       "podReplicas": {
                         "type": "number",
-                        "default": 1
+                        "default": 1,
+                        "description": "Number of RFS (Reindex From Snapshot) pod replicas in the Kubernetes Deployment. Each replica processes shards independently using distributed work coordination."
                       },
                       "jvmArgs": {
                         "type": "string",
-                        "default": ""
+                        "default": "",
+                        "description": "Additional JVM arguments passed to the RFS process via JDK_JAVA_OPTIONS (e.g. '-Xmx6g'). Tune based on shard sizes and available memory."
                       },
                       "loggingConfigurationOverrideConfigMap": {
                         "type": "string",
-                        "default": ""
+                        "default": "",
+                        "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the RFS process."
                       },
                       "skipApproval": {
                         "type": "boolean",
-                        "default": false
+                        "default": false,
+                        "description": "When true, skips the manual approval gate before starting the document backfill. Useful for automated pipelines where human approval is not needed."
                       },
                       "useTargetClusterForWorkCoordination": {
                         "type": "boolean",
                         "default": false,
-                        "description": "When true, uses the target OpenSearch cluster for RFS work coordination. When false, a dedicated single-node OpenSearch coordinator cluster is deployed and managed for the lifetime of the migration, then torn down on completion."
+                        "description": "When true, uses the target OpenSearch cluster for RFS work coordination (lease management and shard assignment). When false (default), a dedicated single-node OpenSearch coordinator cluster is automatically deployed, used for the lifetime of the migration, then torn down on completion. Using a dedicated coordinator avoids adding coordination overhead to the target cluster."
                       },
                       "resources": {
                         "type": "object",
@@ -1939,24 +2062,24 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                               "cpu": {
                                 "type": "string",
                                 "pattern": "^[0-9]+m$",
-                                "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                                "description": "CPU allocation for the container in Kubernetes millicores."
                               },
                               "memory": {
                                 "type": "string",
                                 "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                                "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                                "description": "Memory allocation for the container."
                               },
                               "ephemeral-storage": {
                                 "type": "string",
                                 "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                                "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                                "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                               }
                             },
                             "required": [
                               "cpu",
                               "memory"
                             ],
-                            "description": "Resource upper bound for a container"
+                            "description": "Maximum resource limits for the container. The container will be terminated if it exceeds these limits."
                           },
                           "requests": {
                             "type": "object",
@@ -1964,81 +2087,91 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                               "cpu": {
                                 "type": "string",
                                 "pattern": "^[0-9]+m$",
-                                "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                                "description": "CPU allocation for the container in Kubernetes millicores."
                               },
                               "memory": {
                                 "type": "string",
                                 "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                                "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                                "description": "Memory allocation for the container."
                               },
                               "ephemeral-storage": {
                                 "type": "string",
                                 "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                                "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                                "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                               }
                             },
                             "required": [
                               "cpu",
                               "memory"
                             ],
-                            "description": "Resource lower bound for a container"
+                            "description": "Minimum guaranteed resources for the container. Used by the Kubernetes scheduler for pod placement."
                           }
                         },
                         "required": [
                           "limits",
                           "requests"
                         ],
-                        "description": "Resource limits and requests for RFS container"
+                        "description": "Kubernetes resource limits and requests for the RFS container. Defaults to 3300m CPU and 7000Mi memory. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."
                       },
                       "indexAllowlist": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "default": []
+                        "default": [],
+                        "description": "List of index name patterns to include in the document backfill. An empty list means all indices from the snapshot are migrated."
                       },
                       "allowLooseVersionMatching": {
                         "type": "boolean",
                         "default": true,
-                        "description": ""
+                        "description": "When true, allows document migration between clusters with non-exact version compatibility."
                       },
                       "docTransformerConfigBase64": {
                         "type": "string",
-                        "default": ""
+                        "default": "",
+                        "description": "Base64-encoded JSON configuration for document transformers. Defines custom transformations applied to each document during the backfill (e.g. field renaming, type conversion)."
                       },
                       "documentsPerBulkRequest": {
                         "type": "number",
-                        "default": 2147483647
+                        "default": 2147483647,
+                        "description": "Maximum number of documents per bulk indexing request to the target cluster. Default is 2147483647 (effectively unlimited, bounded by request size). Lower values reduce per-request latency but increase overhead."
                       },
                       "initialLeaseDuration": {
                         "type": "string",
-                        "default": "PT1H"
+                        "default": "PT1H",
+                        "description": "ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up."
                       },
                       "maxConnections": {
                         "type": "number",
-                        "default": 10
+                        "default": 10,
+                        "description": "Maximum number of concurrent HTTP connections from each RFS worker to the target cluster for bulk indexing."
                       },
                       "maxShardSizeBytes": {
                         "type": "number",
-                        "default": 85899345920
+                        "default": 85899345920,
+                        "description": "Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Default is 85899345920 (80 GiB). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."
                       },
                       "otelCollectorEndpoint": {
                         "type": "string",
-                        "default": "http://otel-collector:4317"
+                        "default": "http://otel-collector:4317",
+                        "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector for RFS backfill metrics and progress tracking."
                       }
-                    }
+                    },
+                    "description": "Configuration for backfilling documents from the snapshot to the target using Reindex From Snapshot. Omit to skip document backfill."
                   }
                 }
               },
               "minItems": 1
-            }
+            },
+            "description": "Per-snapshot migration configurations. Each entry maps a snapshot name to one or more migration passes (metadata + document backfill)."
           }
         },
         "required": [
           "fromSource",
           "toTarget"
         ]
-      }
+      },
+      "description": "List of snapshot-based migration configurations. Each entry binds a source cluster to a target cluster and defines which snapshots to migrate with what settings."
     },
     "traffic": {
       "type": "object",
@@ -2051,32 +2184,36 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
               "kafka": {
                 "type": "string",
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                "default": "default"
+                "default": "default",
+                "description": "Name of the Kafka cluster to use for captured traffic. Must match a key in kafkaClusterConfiguration. Defaults to 'default', which auto-creates a cluster if none is configured."
               },
               "kafkaTopic": {
                 "type": "string",
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                 "default": "",
-                "description": "Kafka topic for captured traffic. Empty defaults to the proxy name."
+                "description": "Kafka topic name for captured traffic. If empty, defaults to the proxy name (the key in the proxies record)."
               },
               "source": {
-                "type": "string"
+                "type": "string",
+                "description": "Name of the source cluster this proxy sits in front of. Must match a key in sourceClusters."
               },
               "proxyConfig": {
                 "type": "object",
                 "properties": {
                   "loggingConfigurationOverrideConfigMap": {
                     "type": "string",
-                    "default": ""
+                    "default": "",
+                    "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration. When set, the ConfigMap is mounted into the container and used to override default logging. Leave empty to use built-in logging defaults."
                   },
                   "internetFacing": {
                     "type": "boolean",
                     "default": false,
-                    "description": "When true, configures the proxy Service load balancer scheme as internet-facing."
+                    "description": "When true, the proxy's Kubernetes Service is annotated with 'internet-facing' load balancer scheme, making it accessible from outside the VPC. When false (default), the load balancer is internal-only."
                   },
                   "podReplicas": {
                     "type": "number",
-                    "default": 1
+                    "default": 1,
+                    "description": "Number of proxy pod replicas in the Kubernetes Deployment. Increase for higher throughput or availability."
                   },
                   "resources": {
                     "type": "object",
@@ -2088,24 +2225,24 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "cpu": {
                             "type": "string",
                             "pattern": "^[0-9]+m$",
-                            "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                            "description": "CPU allocation for the container in Kubernetes millicores."
                           },
                           "memory": {
                             "type": "string",
                             "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                            "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                            "description": "Memory allocation for the container."
                           },
                           "ephemeral-storage": {
                             "type": "string",
                             "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                            "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                            "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                           }
                         },
                         "required": [
                           "cpu",
                           "memory"
                         ],
-                        "description": "Resource upper bound for a container"
+                        "description": "Maximum resource limits for the container. The container will be terminated if it exceeds these limits."
                       },
                       "requests": {
                         "type": "object",
@@ -2113,24 +2250,24 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "cpu": {
                             "type": "string",
                             "pattern": "^[0-9]+m$",
-                            "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                            "description": "CPU allocation for the container in Kubernetes millicores."
                           },
                           "memory": {
                             "type": "string",
                             "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                            "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                            "description": "Memory allocation for the container."
                           },
                           "ephemeral-storage": {
                             "type": "string",
                             "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                            "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                            "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                           }
                         },
                         "required": [
                           "cpu",
                           "memory"
                         ],
-                        "description": "Resource lower bound for a container"
+                        "description": "Minimum guaranteed resources for the container. Used by the Kubernetes scheduler for pod placement."
                       }
                     },
                     "default": {
@@ -2147,49 +2284,58 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "limits",
                       "requests"
                     ],
-                    "description": "Resource limits and requests for proxy container."
+                    "description": "Kubernetes resource limits and requests for the capture proxy container. Defaults to 3500m CPU and 3500Mi memory for both limits and requests (Guaranteed QoS)."
                   },
                   "otelCollectorEndpoint": {
                     "type": "string",
-                    "default": "http://otel-collector:4317"
+                    "default": "http://otel-collector:4317",
+                    "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector. The proxy sends metrics and traces to this endpoint. Default points to the in-cluster collector service."
                   },
                   "setHeader": {
                     "type": "array",
                     "items": {
                       "type": "string"
-                    }
+                    },
+                    "description": "List of static headers to add to proxied requests, each in 'Header-Name: value' format."
                   },
                   "destinationConnectionPoolSize": {
                     "type": "number",
-                    "default": 0
+                    "default": 0,
+                    "description": "Maximum number of persistent connections to the destination (source) cluster. 0 means unlimited/default connection pooling."
                   },
                   "destinationConnectionPoolTimeout": {
                     "type": "string",
                     "pattern": "^[-+]?P(?:(\\\\d+)D)?(?:T(?:(\\\\d+)H)?(?:(\\\\d+)M)?(?:(\\\\d+(?:\\\\.\\\\d+)?)S)?)?$",
-                    "default": "PT30S"
+                    "default": "PT30S",
+                    "description": "ISO 8601 duration for how long idle connections in the destination pool are kept alive before being closed (e.g. 'PT30S' = 30 seconds, 'PT5M' = 5 minutes)."
                   },
                   "kafkaClientId": {
                     "type": "string",
-                    "default": "HttpCaptureProxyProducer"
+                    "default": "HttpCaptureProxyProducer",
+                    "description": "Kafka producer client ID used when publishing captured traffic to Kafka. Useful for identifying this proxy in Kafka broker logs and metrics."
                   },
                   "listenPort": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "TCP port the capture proxy listens on for incoming HTTP(S) traffic. This port is exposed via the Kubernetes Service and used to construct the proxy endpoint URL."
                   },
                   "maxTrafficBufferSize": {
                     "type": "number",
-                    "default": 1048576
+                    "default": 1048576,
+                    "description": "Maximum size in bytes for buffering a single HTTP request/response payload before forwarding to Kafka. Default is 1048576 (1 MiB)."
                   },
                   "noCapture": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "When true, the proxy forwards traffic to the source cluster without capturing it to Kafka. Useful for TLS termination or routing without traffic recording."
                   },
                   "numThreads": {
                     "type": "number",
-                    "default": 1
+                    "default": 1,
+                    "description": "Number of Netty worker threads for the proxy to handle concurrent connections."
                   },
                   "sslConfigFile": {
                     "type": "string",
-                    "description": "Legacy: YAML config for OpenSearch security SSL. Prefer tls config for K8s deployments."
+                    "description": "Path to a YAML file with OpenSearch security SSL configuration (plugins.security.ssl.http.* keys). Legacy option for non-Kubernetes deployments. For Kubernetes, prefer the 'tls' configuration instead."
                   },
                   "tls": {
                     "oneOf": [
@@ -2200,14 +2346,15 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                             "type": "string",
                             "enum": [
                               "certManager"
-                            ]
+                            ],
+                            "description": "Use cert-manager to automatically provision and renew a TLS certificate."
                           },
                           "issuerRef": {
                             "type": "object",
                             "properties": {
                               "name": {
                                 "type": "string",
-                                "description": "Name of the cert-manager Issuer or ClusterIssuer."
+                                "description": "Name of the cert-manager Issuer or ClusterIssuer resource that will sign the certificate."
                               },
                               "kind": {
                                 "type": "string",
@@ -2216,20 +2363,22 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                                   "ClusterIssuer"
                                 ],
                                 "default": "ClusterIssuer",
-                                "description": "Kind of the issuer resource."
+                                "description": "Kind of the cert-manager issuer resource. 'ClusterIssuer' is cluster-scoped; 'Issuer' is namespace-scoped."
                               },
                               "group": {
                                 "type": "string",
                                 "default": "cert-manager.io",
-                                "description": "API group of the issuer. Use 'awspca.cert-manager.io' for AWS PCA issuers."
+                                "description": "API group of the issuer. Use 'cert-manager.io' for standard issuers or 'awspca.cert-manager.io' for AWS Private CA issuers."
                               }
                             },
                             "required": [
                               "name"
-                            ]
+                            ],
+                            "description": "Reference to a cert-manager issuer that will sign TLS certificates for the proxy."
                           },
                           "commonName": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Optional common name (CN) for the TLS certificate subject."
                           },
                           "dnsNames": {
                             "type": "array",
@@ -2237,17 +2386,17 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                               "type": "string"
                             },
                             "minItems": 1,
-                            "description": "DNS names for the certificate. Must include the proxy's service DNS name."
+                            "description": "DNS Subject Alternative Names for the certificate. Must include the proxy's Kubernetes service DNS name (e.g. 'my-proxy.default.svc.cluster.local')."
                           },
                           "duration": {
                             "type": "string",
                             "default": "2160h",
-                            "description": "Requested certificate validity duration (default: 90 days)."
+                            "description": "Requested certificate validity duration in Go duration format. Default is '2160h' (90 days)."
                           },
                           "renewBefore": {
                             "type": "string",
                             "default": "360h",
-                            "description": "How long before expiry to renew (default: 15 days)."
+                            "description": "How long before certificate expiry to trigger renewal. Default is '360h' (15 days)."
                           }
                         },
                         "required": [
@@ -2255,7 +2404,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "issuerRef",
                           "dnsNames"
                         ],
-                        "description": "Use cert-manager to provision a TLS certificate for the proxy."
+                        "description": "Provision a TLS certificate via cert-manager. A Certificate resource is created and the resulting secret is mounted into the proxy pod."
                       },
                       {
                         "type": "object",
@@ -2264,56 +2413,65 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                             "type": "string",
                             "enum": [
                               "existingSecret"
-                            ]
+                            ],
+                            "description": "Use a pre-existing Kubernetes TLS secret."
                           },
                           "secretName": {
                             "type": "string",
-                            "description": "Name of an existing K8s TLS secret with tls.crt and tls.key."
+                            "description": "Name of an existing Kubernetes TLS secret containing 'tls.crt' and 'tls.key' entries. The secret is mounted into the proxy pod at /etc/proxy-tls/."
                           }
                         },
                         "required": [
                           "mode",
                           "secretName"
                         ],
-                        "description": "Use a pre-existing K8s TLS secret."
+                        "description": "Use a pre-existing Kubernetes TLS secret for proxy HTTPS termination."
                       }
                     ],
-                    "description": "TLS certificate configuration for the proxy. Mutually exclusive with sslConfigFile."
+                    "description": "TLS certificate configuration for HTTPS termination at the proxy. When configured, the proxy serves HTTPS and the TLS secret is mounted at /etc/proxy-tls/. Mutually exclusive with sslConfigFile."
                   },
                   "enableMSKAuth": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Enable SASL/IAM authentication for the proxy's Kafka producer when connecting to Amazon MSK."
                   },
                   "suppressCaptureForHeaderMatch": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "default": []
+                    "default": [],
+                    "description": "List of header patterns. Requests matching any of these header patterns will be forwarded but not captured to Kafka."
                   },
                   "suppressCaptureForMethod": {
                     "type": "string",
-                    "default": ""
+                    "default": "",
+                    "description": "HTTP method to suppress from capture (e.g. 'HEAD'). Requests with this method are forwarded but not recorded."
                   },
                   "suppressCaptureForUriPath": {
                     "type": "string",
-                    "default": ""
+                    "default": "",
+                    "description": "URI path pattern to suppress from capture. Requests matching this path are forwarded but not recorded."
                   },
                   "suppressMethodAndPath": {
                     "type": "string",
-                    "default": ""
+                    "default": "",
+                    "description": "Combined method and path pattern for capture suppression in 'METHOD /path' format."
                   }
                 },
                 "required": [
                   "listenPort"
-                ]
+                ],
+                "description": "Configuration for the capture proxy deployment and process options."
               }
             },
             "required": [
               "source",
               "proxyConfig"
-            ]
-          }
+            ],
+            "description": "Configuration for a single capture proxy instance, including its Kafka topic and source cluster binding."
+          },
+          "description": "Map of proxy names to their capture configurations. Keys become the Kubernetes Service names and must be valid DNS labels."
         },
         "replayers": {
           "type": "object",
@@ -2322,13 +2480,16 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
             "properties": {
               "skipApprovals": {
                 "type": "boolean",
-                "default": false
+                "default": false,
+                "description": "When true, skips all manual approval gates for this replayer."
               },
               "fromProxy": {
-                "type": "string"
+                "type": "string",
+                "description": "Name of the capture proxy to replay traffic from. Must match a key in traffic.proxies."
               },
               "toTarget": {
-                "type": "string"
+                "type": "string",
+                "description": "Name of the target cluster to replay traffic to. Must match a key in targetClusters."
               },
               "dependsOnSnapshotMigrations": {
                 "type": "array",
@@ -2336,33 +2497,40 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "type": "object",
                   "properties": {
                     "source": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Name of the source cluster. Must match a key in sourceClusters."
                     },
                     "snapshot": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Name of the snapshot. Must match a key in the source cluster's snapshotInfo.snapshots."
                     }
                   },
                   "required": [
                     "source",
                     "snapshot"
-                  ]
+                  ],
+                  "description": "Reference to a specific snapshot from a specific source cluster, used to express dependencies."
                 },
-                "default": []
+                "default": [],
+                "description": "List of snapshot migrations that must complete before this replayer starts. Ensures data consistency when replaying traffic that depends on backfilled data."
               },
               "replayerConfig": {
                 "type": "object",
                 "properties": {
                   "jvmArgs": {
                     "type": "string",
-                    "default": ""
+                    "default": "",
+                    "description": "Additional JVM arguments passed to the replayer process via JDK_JAVA_OPTIONS (e.g. '-Xmx4g -XX:+UseG1GC'). Leave empty for JVM defaults."
                   },
                   "loggingConfigurationOverrideConfigMap": {
                     "type": "string",
-                    "default": ""
+                    "default": "",
+                    "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the replayer. Leave empty to use built-in logging defaults."
                   },
                   "podReplicas": {
                     "type": "number",
-                    "default": 1
+                    "default": 1,
+                    "description": "Number of replayer pod replicas in the Kubernetes Deployment. Each replica independently consumes from Kafka and replays traffic to the target."
                   },
                   "resources": {
                     "type": "object",
@@ -2374,24 +2542,24 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "cpu": {
                             "type": "string",
                             "pattern": "^[0-9]+m$",
-                            "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                            "description": "CPU allocation for the container in Kubernetes millicores."
                           },
                           "memory": {
                             "type": "string",
                             "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                            "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                            "description": "Memory allocation for the container."
                           },
                           "ephemeral-storage": {
                             "type": "string",
                             "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                            "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                            "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                           }
                         },
                         "required": [
                           "cpu",
                           "memory"
                         ],
-                        "description": "Resource upper bound for a container"
+                        "description": "Maximum resource limits for the container. The container will be terminated if it exceeds these limits."
                       },
                       "requests": {
                         "type": "object",
@@ -2399,101 +2567,101 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "cpu": {
                             "type": "string",
                             "pattern": "^[0-9]+m$",
-                            "description": "CPU quantity in millicores (e.g., '100m', '500m')"
+                            "description": "CPU allocation for the container in Kubernetes millicores."
                           },
                           "memory": {
                             "type": "string",
                             "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                            "description": "Memory quantity with unit (e.g., '512Mi', '2G')"
+                            "description": "Memory allocation for the container."
                           },
                           "ephemeral-storage": {
                             "type": "string",
                             "pattern": "^[0-9]+(([EPTGM])i?|Ki|k)$",
-                            "description": "Storage quantity with unit (e.g., '10Gi', '5G')"
+                            "description": "Ephemeral storage allocation for the container. Used for temporary on-disk data such as Lucene index segments during RFS document migration."
                           }
                         },
                         "required": [
                           "cpu",
                           "memory"
                         ],
-                        "description": "Resource lower bound for a container"
+                        "description": "Minimum guaranteed resources for the container. Used by the Kubernetes scheduler for pod placement."
                       }
                     },
                     "required": [
                       "limits",
                       "requests"
                     ],
-                    "description": "Resource limits and requests for replayer container."
+                    "description": "Kubernetes resource limits and requests for the replayer container. Defaults to 3500m CPU and 3500Mi memory (Guaranteed QoS)."
                   },
                   "kafkaTrafficEnableMSKAuth": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enables SASL properties required for connecting to MSK with IAM auth."
+                    "description": "Enable SASL/IAM authentication for the replayer's Kafka consumer when connecting to Amazon MSK."
                   },
                   "kafkaTrafficPropertyFile": {
                     "type": "string",
-                    "description": "File path for Kafka properties file for additional or overridden Kafka properties."
+                    "description": "Path to a Java properties file with additional or overridden Kafka consumer configuration. Mounted into the replayer container."
                   },
                   "lookaheadTimeSeconds": {
                     "type": "number",
                     "default": 400,
-                    "description": "Number of seconds of data that will be buffered."
+                    "description": "Number of seconds of captured traffic to buffer ahead of the current replay position. Larger values improve throughput but increase memory usage."
                   },
                   "maxConcurrentRequests": {
                     "type": "number",
                     "default": 10000,
-                    "description": "Maximum number of requests that can be outstanding at a time."
+                    "description": "Maximum number of HTTP requests that can be in-flight simultaneously to the target cluster. Limits concurrency to prevent overwhelming the target."
                   },
                   "numClientThreads": {
                     "type": "number",
                     "default": 0,
-                    "description": "Number of threads to use to send requests from."
+                    "description": "Number of threads used to send replayed requests to the target. 0 uses the Netty default (typically number of available processors)."
                   },
                   "observedPacketConnectionTimeout": {
                     "type": "number",
                     "default": 360,
-                    "description": "Seconds of inactivity before assuming connections were terminated in the captured stream."
+                    "description": "Seconds of inactivity on a captured connection before assuming it was terminated in the original traffic stream."
                   },
                   "otelCollectorEndpoint": {
                     "type": "string",
                     "default": "http://otel-collector:4317",
-                    "description": "Endpoint (host:port) for the OpenTelemetry Collector for metrics forwarding."
+                    "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector. The replayer sends metrics and traces to this endpoint for monitoring replay progress."
                   },
                   "quiescentPeriodMs": {
                     "type": "number",
                     "default": 5000,
-                    "description": "Milliseconds to delay the first request on a resumed connection after Kafka partition reassignment."
+                    "description": "Milliseconds to delay the first request on a resumed connection after a Kafka partition reassignment. Prevents request bursts during rebalancing."
                   },
                   "removeAuthHeader": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Remove the authorization header if present without replacing it."
+                    "description": "Remove the Authorization header from replayed requests without replacing it. Useful when the target uses a different auth mechanism (e.g. SigV4) configured separately."
                   },
                   "speedupFactor": {
                     "type": "number",
                     "default": 1.1,
-                    "description": "Factor to accelerate replayed communications relative to original timing."
+                    "description": "Multiplier to accelerate replay timing relative to the original captured traffic. 1.0 = real-time, 2.0 = double speed. Default 1.1 provides a slight speedup to keep replay ahead of capture."
                   },
                   "targetServerResponseTimeoutSeconds": {
                     "type": "number",
                     "default": 150,
-                    "description": "Seconds to wait before timing out a replayed request to the target."
+                    "description": "Maximum seconds to wait for a response from the target cluster before timing out a replayed request."
                   },
                   "transformerConfig": {
                     "type": "string",
-                    "description": "Request transformer configuration as a string or JSON."
+                    "description": "Inline request transformer configuration as a JSON string. Defines transformations applied to each request before replaying to the target."
                   },
                   "transformerConfigEncoded": {
                     "type": "string",
-                    "description": "Base64-encoded request transformer configuration."
+                    "description": "Base64-encoded request transformer configuration. Alternative to transformerConfig for configurations containing special characters."
                   },
                   "transformerConfigFile": {
                     "type": "string",
-                    "description": "Path to the JSON configuration file for request transformers."
+                    "description": "Path to a JSON file containing request transformer configuration. The file is read from the container filesystem."
                   },
                   "tupleTransformerConfig": {
                     "type": "string",
-                    "description": "Tuple transformer configuration as a string or JSON."
+                    "description": "Inline tuple transformer configuration as a JSON string. Tuple transformers operate on request-response pairs for stateful transformations."
                   },
                   "tupleTransformerConfigBase64": {
                     "type": "string",
@@ -2501,27 +2669,30 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   },
                   "tupleTransformerConfigFile": {
                     "type": "string",
-                    "description": "Path to the JSON configuration file for tuple transformers."
+                    "description": "Path to a JSON file containing tuple transformer configuration."
                   },
                   "userAgent": {
                     "type": "string",
-                    "description": "String appended to the user-agent header for requests to the target cluster."
+                    "description": "String appended to the User-Agent header on all replayed requests to the target cluster. Useful for identifying replayed traffic in target cluster logs."
                   }
-                }
+                },
+                "description": "Optional replayer configuration overrides. If omitted, default replayer settings are used."
               }
             },
             "required": [
               "fromProxy",
               "toTarget"
-            ]
-          }
+            ],
+            "description": "Configuration for a single traffic replayer instance, binding a proxy's captured traffic to a target cluster."
+          },
+          "description": "Map of replayer names to their replay configurations. Each replayer consumes from a proxy's Kafka topic and replays to a target cluster."
         }
       },
       "required": [
         "proxies",
         "replayers"
       ],
-      "description": "Top-level items are independent of each other but items in the inner-arrays require all snapshot activities across each of the items' sources to finish before any replays in this group can start."
+      "description": "Traffic capture and replay configuration. Proxies capture live traffic from source clusters to Kafka, and replayers consume from Kafka to replay against target clusters. All top-level items are independent, but replayers can declare dependencies on snapshot migrations to ensure data consistency."
     }
   },
   "required": [

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -222,7 +222,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                         "limits",
                         "requests"
                       ],
-                      "description": "Kubernetes resource limits and requests for the capture proxy container. Defaults to 3500m CPU and 3500Mi memory for both limits and requests (Guaranteed QoS)."
+                      "description": "Kubernetes resource limits and requests for the capture proxy container. Partial overrides are deep-merged with the built-in defaults (Guaranteed QoS)."
                     },
                     "otelCollectorEndpoint": {
                       "type": "string",
@@ -322,12 +322,12 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                             "duration": {
                               "type": "string",
                               "default": "2160h",
-                              "description": "Requested certificate validity duration in Go duration format. Default is '2160h' (90 days)."
+                              "description": "Requested certificate validity duration in Go duration format (e.g. '2160h' = 90 days)."
                             },
                             "renewBefore": {
                               "type": "string",
                               "default": "360h",
-                              "description": "How long before certificate expiry to trigger renewal. Default is '360h' (15 days)."
+                              "description": "How long before certificate expiry to trigger renewal (e.g. '360h' = 15 days)."
                             }
                           },
                           "required": [
@@ -844,7 +844,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                               "limits",
                               "requests"
                             ],
-                            "description": "Kubernetes resource limits and requests for the RFS container. Defaults to 3300m CPU and 7000Mi memory. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."
+                            "description": "Kubernetes resource limits and requests for the RFS container. Partial overrides are deep-merged with the built-in defaults. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."
                           },
                           "indexAllowlist": {
                             "type": "array",
@@ -1189,7 +1189,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                         "limits",
                         "requests"
                       ],
-                      "description": "Kubernetes resource limits and requests for the replayer container. Defaults to 3500m CPU and 3500Mi memory (Guaranteed QoS)."
+                      "description": "Kubernetes resource limits and requests for the replayer container. Partial overrides are deep-merged with the built-in defaults (Guaranteed QoS)."
                     },
                     "kafkaTrafficEnableMSKAuth": {
                       "type": "boolean",
@@ -1460,7 +1460,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "type": "integer",
                     "minimum": 1,
                     "default": 1,
-                    "description": "Default number of partitions for auto-created Kafka topics. More partitions enable higher parallelism for consumers."
+                    "description": "Number of partitions for auto-created Kafka topics. More partitions enable higher parallelism for consumers."
                   },
                   "topicReplicas": {
                     "type": "integer",
@@ -1636,7 +1636,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "type": "string",
                       "pattern": "(?:^(http|localstack)s?:\\\\/\\\\/[^/]*\\\\/?$)?",
                       "default": "",
-                      "description": "Override the default S3 endpoint URL. Supports http://, https://, localstack://, and localstacks:// schemes. LocalStack endpoints are automatically resolved to IP addresses during config transformation. Leave empty to use the default AWS S3 endpoint."
+                      "description": "Override the S3 endpoint URL. Supports http://, https://, localstack://, and localstacks:// schemes. LocalStack endpoints are automatically resolved to IP addresses during config transformation."
                     },
                     "s3RepoPathUri": {
                       "type": "string",
@@ -1697,7 +1697,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                                 "loggingConfigurationOverrideConfigMap": {
                                   "type": "string",
                                   "default": "",
-                                  "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the snapshot creation process. Leave empty for defaults."
+                                  "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the snapshot creation process."
                                 },
                                 "indexAllowlist": {
                                   "type": "array",
@@ -2111,7 +2111,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "limits",
                           "requests"
                         ],
-                        "description": "Kubernetes resource limits and requests for the RFS container. Defaults to 3300m CPU and 7000Mi memory. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."
+                        "description": "Kubernetes resource limits and requests for the RFS container. Partial overrides are deep-merged with the built-in defaults. Ephemeral storage is auto-calculated from maxShardSizeBytes if not specified."
                       },
                       "indexAllowlist": {
                         "type": "array",
@@ -2134,7 +2134,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "documentsPerBulkRequest": {
                         "type": "number",
                         "default": 2147483647,
-                        "description": "Maximum number of documents per bulk indexing request to the target cluster. Default is 2147483647 (effectively unlimited, bounded by request size). Lower values reduce per-request latency but increase overhead."
+                        "description": "Maximum number of documents per bulk indexing request to the target cluster. Lower values reduce per-request latency but increase overhead."
                       },
                       "initialLeaseDuration": {
                         "type": "string",
@@ -2149,7 +2149,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "maxShardSizeBytes": {
                         "type": "number",
                         "default": 85899345920,
-                        "description": "Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Default is 85899345920 (80 GiB). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."
+                        "description": "Expected maximum shard size in bytes. Used to auto-calculate ephemeral storage requirements as ceil(2.5 * maxShardSizeBytes). Set this to match your largest shard to ensure sufficient disk space for Lucene segment processing."
                       },
                       "otelCollectorEndpoint": {
                         "type": "string",
@@ -2203,12 +2203,12 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "loggingConfigurationOverrideConfigMap": {
                     "type": "string",
                     "default": "",
-                    "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration. When set, the ConfigMap is mounted into the container and used to override default logging. Leave empty to use built-in logging defaults."
+                    "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration. When set, the ConfigMap is mounted into the container to override logging behavior."
                   },
                   "internetFacing": {
                     "type": "boolean",
                     "default": false,
-                    "description": "When true, the proxy's Kubernetes Service is annotated with 'internet-facing' load balancer scheme, making it accessible from outside the VPC. When false (default), the load balancer is internal-only."
+                    "description": "When true, the proxy's Kubernetes Service is annotated with 'internet-facing' load balancer scheme, making it accessible from outside the VPC."
                   },
                   "podReplicas": {
                     "type": "number",
@@ -2284,12 +2284,12 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "limits",
                       "requests"
                     ],
-                    "description": "Kubernetes resource limits and requests for the capture proxy container. Defaults to 3500m CPU and 3500Mi memory for both limits and requests (Guaranteed QoS)."
+                    "description": "Kubernetes resource limits and requests for the capture proxy container. Partial overrides are deep-merged with the built-in defaults (Guaranteed QoS)."
                   },
                   "otelCollectorEndpoint": {
                     "type": "string",
                     "default": "http://otel-collector:4317",
-                    "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector. The proxy sends metrics and traces to this endpoint. Default points to the in-cluster collector service."
+                    "description": "gRPC endpoint (host:port) for the OpenTelemetry Collector. The proxy sends metrics and traces to this endpoint."
                   },
                   "setHeader": {
                     "type": "array",
@@ -2301,7 +2301,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "destinationConnectionPoolSize": {
                     "type": "number",
                     "default": 0,
-                    "description": "Maximum number of persistent connections to the destination (source) cluster. 0 means unlimited/default connection pooling."
+                    "description": "Maximum number of persistent connections to the destination (source) cluster. 0 means unlimited connection pooling."
                   },
                   "destinationConnectionPoolTimeout": {
                     "type": "string",
@@ -2321,7 +2321,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "maxTrafficBufferSize": {
                     "type": "number",
                     "default": 1048576,
-                    "description": "Maximum size in bytes for buffering a single HTTP request/response payload before forwarding to Kafka. Default is 1048576 (1 MiB)."
+                    "description": "Maximum size in bytes for buffering a single HTTP request/response payload before forwarding to Kafka."
                   },
                   "noCapture": {
                     "type": "boolean",
@@ -2391,12 +2391,12 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "duration": {
                             "type": "string",
                             "default": "2160h",
-                            "description": "Requested certificate validity duration in Go duration format. Default is '2160h' (90 days)."
+                            "description": "Requested certificate validity duration in Go duration format (e.g. '2160h' = 90 days)."
                           },
                           "renewBefore": {
                             "type": "string",
                             "default": "360h",
-                            "description": "How long before certificate expiry to trigger renewal. Default is '360h' (15 days)."
+                            "description": "How long before certificate expiry to trigger renewal (e.g. '360h' = 15 days)."
                           }
                         },
                         "required": [
@@ -2520,12 +2520,12 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "jvmArgs": {
                     "type": "string",
                     "default": "",
-                    "description": "Additional JVM arguments passed to the replayer process via JDK_JAVA_OPTIONS (e.g. '-Xmx4g -XX:+UseG1GC'). Leave empty for JVM defaults."
+                    "description": "Additional JVM arguments passed to the replayer process via JDK_JAVA_OPTIONS (e.g. '-Xmx4g -XX:+UseG1GC')."
                   },
                   "loggingConfigurationOverrideConfigMap": {
                     "type": "string",
                     "default": "",
-                    "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the replayer. Leave empty to use built-in logging defaults."
+                    "description": "Name of a Kubernetes ConfigMap containing a custom Log4j configuration for the replayer."
                   },
                   "podReplicas": {
                     "type": "number",
@@ -2591,7 +2591,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "limits",
                       "requests"
                     ],
-                    "description": "Kubernetes resource limits and requests for the replayer container. Defaults to 3500m CPU and 3500Mi memory (Guaranteed QoS)."
+                    "description": "Kubernetes resource limits and requests for the replayer container. Partial overrides are deep-merged with the built-in defaults (Guaranteed QoS)."
                   },
                   "kafkaTrafficEnableMSKAuth": {
                     "type": "boolean",
@@ -2615,7 +2615,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "numClientThreads": {
                     "type": "number",
                     "default": 0,
-                    "description": "Number of threads used to send replayed requests to the target. 0 uses the Netty default (typically number of available processors)."
+                    "description": "Number of threads used to send replayed requests to the target. 0 uses the Netty event loop (typically number of available processors)."
                   },
                   "observedPacketConnectionTimeout": {
                     "type": "number",
@@ -2640,7 +2640,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "speedupFactor": {
                     "type": "number",
                     "default": 1.1,
-                    "description": "Multiplier to accelerate replay timing relative to the original captured traffic. 1.0 = real-time, 2.0 = double speed. Default 1.1 provides a slight speedup to keep replay ahead of capture."
+                    "description": "Multiplier to accelerate replay timing relative to the original captured traffic. 1.0 = real-time, 2.0 = double speed."
                   },
                   "targetServerResponseTimeoutSeconds": {
                     "type": "number",
@@ -2676,7 +2676,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                     "description": "String appended to the User-Agent header on all replayed requests to the target cluster. Useful for identifying replayed traffic in target cluster logs."
                   }
                 },
-                "description": "Optional replayer configuration overrides. If omitted, default replayer settings are used."
+                "description": "Optional replayer configuration overrides. If omitted, replayer runs with schema defaults."
               }
             },
             "required": [

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -887,6 +887,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "initialLeaseDuration": {
                             "type": "string",
+                            "pattern": "^[-+]?P(?:(\\\\d+)D)?(?:T(?:(\\\\d+)H)?(?:(\\\\d+)M)?(?:(\\\\d+(?:\\\\.\\\\d+)?)S)?)?$",
                             "default": "PT1H"
                           },
                           "maxConnections": {
@@ -2215,6 +2216,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       },
                       "initialLeaseDuration": {
                         "type": "string",
+                        "pattern": "^[-+]?P(?:(\\\\d+)D)?(?:T(?:(\\\\d+)H)?(?:(\\\\d+)M)?(?:(\\\\d+(?:\\\\.\\\\d+)?)S)?)?$",
                         "default": "PT1H",
                         "description": "ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up."
                       },

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -2729,7 +2729,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "lookaheadTimeSeconds": {
                     "type": "number",
                     "default": 400,
-                    "description": "Number of seconds of captured traffic to buffer ahead of the current replay position. Larger values improve throughput but increase memory usage."
+                    "description": "Number of seconds of captured traffic to buffer ahead of the current replay position. Must be strictly greater than observedPacketConnectionTimeout. Larger values improve throughput but increase memory usage."
                   },
                   "maxConcurrentRequests": {
                     "type": "number",
@@ -2744,7 +2744,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "observedPacketConnectionTimeout": {
                     "type": "number",
                     "default": 360,
-                    "description": "Seconds of inactivity on a captured connection before assuming it was terminated in the original traffic stream."
+                    "description": "Seconds of inactivity on a captured connection before assuming it was terminated in the original traffic stream. Must be strictly less than lookaheadTimeSeconds."
                   },
                   "otelCollectorEndpoint": {
                     "type": "string",

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -1647,7 +1647,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "type": "string",
                       "pattern": "^(arn:aws:iam::\\\\d{12}:(user|role|group|policy)\\\\/[a-zA-Z0-9+=,.@_-]+)?$",
                       "default": "",
-                      "description": "IAM role ARN to assume when accessing S3 for snapshot operations. Leave empty to use the default credentials of the migration infrastructure."
+                      "description": "IAM role ARN that the source cluster will assume to read/write snapshots to S3. This is passed to the cluster when registering the snapshot repository. Leave empty if the cluster's own IAM role already has S3 access."
                     }
                   },
                   "required": [

--- a/orchestrationSpecs/packages/schemas/tests/fixtures/invalid/proxy-ssl-and-tls-both-set.json
+++ b/orchestrationSpecs/packages/schemas/tests/fixtures/invalid/proxy-ssl-and-tls-both-set.json
@@ -1,0 +1,30 @@
+{
+  "sourceClusters": {
+    "source": {
+      "version": "ES 7.10.2",
+      "endpoint": "http://source:9200"
+    }
+  },
+  "targetClusters": {
+    "target": {
+      "endpoint": "http://target:9200"
+    }
+  },
+  "snapshotMigrationConfigs": [],
+  "traffic": {
+    "proxies": {
+      "proxy1": {
+        "source": "source",
+        "proxyConfig": {
+          "listenPort": 9201,
+          "sslConfigFile": "/path/to/ssl.yml",
+          "tls": {
+            "mode": "existingSecret",
+            "secretName": "my-tls-secret"
+          }
+        }
+      }
+    },
+    "replayers": {}
+  }
+}

--- a/orchestrationSpecs/packages/schemas/tests/fixtures/invalid/replayer-lookahead-lte-timeout.json
+++ b/orchestrationSpecs/packages/schemas/tests/fixtures/invalid/replayer-lookahead-lte-timeout.json
@@ -1,0 +1,34 @@
+{
+  "sourceClusters": {
+    "source": {
+      "version": "ES 7.10.2",
+      "endpoint": "http://source:9200"
+    }
+  },
+  "targetClusters": {
+    "target": {
+      "endpoint": "http://target:9200"
+    }
+  },
+  "snapshotMigrationConfigs": [],
+  "traffic": {
+    "proxies": {
+      "proxy1": {
+        "source": "source",
+        "proxyConfig": {
+          "listenPort": 9201
+        }
+      }
+    },
+    "replayers": {
+      "replayer1": {
+        "fromProxy": "proxy1",
+        "toTarget": "target",
+        "replayerConfig": {
+          "lookaheadTimeSeconds": 300,
+          "observedPacketConnectionTimeout": 400
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive OpenAPI descriptions to every parameter in `userSchemas.ts`, exposes missing Java CLI parameters, and adds schema-level validations that were previously only enforced at Java runtime.

## Descriptions

- Every Zod schema field now has a `.describe()` for OpenAPI doc generation
- Default values are not restated (already emitted as `"default"` in JSON Schema)
- Allowlist fields document the `regex:` prefix pattern support
- Cross-references between related fields (e.g. `lookaheadTimeSeconds` / `observedPacketConnectionTimeout`)

## New parameters (from Java CLI gaps)

- **CreateSnapshot:** `compressionEnabled`, `includeGlobalState`
- **Metadata:** `transformerConfig` (inline, non-base64)
- **RFS:** `docTransformerConfig`, `documentsSizePerBulkRequest`, `serverGeneratedIds`, `allowedDocExceptionTypes`, `coordinatorRetryMaxRetries`, `coordinatorRetryInitialDelayMs`, `coordinatorRetryMaxDelayMs`

Removed `*ConfigFile` params (replayer, metadata, RFS) — can't mount arbitrary files into workflow containers.

## Schema validations added

- `sslConfigFile` / `tls` mutual exclusivity (`superRefine` on `USER_PROXY_OPTIONS`)
- `lookaheadTimeSeconds > observedPacketConnectionTimeout` (`superRefine` on `USER_REPLAYER_OPTIONS`)
- ISO 8601 regex on `initialLeaseDuration` (matching existing `destinationConnectionPoolTimeout` pattern)
- `z.enum()` instead of `z.union([...].map(z.literal))` for `multiTypeBehavior`, `output`, `serverGeneratedIds`