### PR TITLE
fix(rfs): update remaining TermEntry call sites for 4-arg record

### DIFF
--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/StreamingFieldPostings10.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/StreamingFieldPostings10.java
@@ -172,7 +172,7 @@ final class StreamingFieldPostings10 implements StreamingFieldPostings {
             int startOff = fieldHasOffsets ? c.postings.startOffset() : PostingsSink.NO_OFFSET;
             int endOff = fieldHasOffsets ? c.postings.endOffset() : PostingsSink.NO_OFFSET;
             posOffsets.add(new int[]{pos, startOff, endOff, collected.size()});
-            collected.add(new TermEntry(c.term, startOff, endOff));
+            collected.add(new TermEntry(c.term, pos, startOff, endOff));
         }
     }
 
@@ -199,7 +199,7 @@ final class StreamingFieldPostings10 implements StreamingFieldPostings {
         ArrayList<TermEntry> ordered = new ArrayList<>(posOffsets.size());
         for (int[] po : posOffsets) {
             TermEntry placeholder = collected.get(po[3]);
-            ordered.add(new TermEntry(placeholder.term(), po[1], po[2]));
+            ordered.add(new TermEntry(placeholder.term(), po[0], po[1], po[2]));
         }
         return ordered;
     }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/StreamingFieldPostings9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/StreamingFieldPostings9.java
@@ -246,13 +246,17 @@ final class StreamingFieldPostings9 implements StreamingFieldPostings {
         ArrayList<TermEntry> ordered = new ArrayList<>(n);
         if (fieldHasOffsets) {
             for (int k = 0; k < n; k++) {
-                int idx = (int) scratchSortKey[k];
-                ordered.add(new TermEntry(scratchTerm[idx], scratchStart[idx], scratchEnd[idx]));
+                long key = scratchSortKey[k];
+                int idx = (int) key;
+                int pos = (int) (key >>> 32);
+                ordered.add(new TermEntry(scratchTerm[idx], pos, scratchStart[idx], scratchEnd[idx]));
             }
         } else {
             for (int k = 0; k < n; k++) {
-                int idx = (int) scratchSortKey[k];
-                ordered.add(new TermEntry(scratchTerm[idx], PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET));
+                long key = scratchSortKey[k];
+                int idx = (int) key;
+                int pos = (int) (key >>> 32);
+                ordered.add(new TermEntry(scratchTerm[idx], pos, PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET));
             }
         }
         return ordered;


### PR DESCRIPTION
### Summary

`5907211b` ("Reconstruct per-element text in object arrays under `_source.excludes`") added a `position` field to the `TermEntry` record:

```java
public record TermEntry(String term, int position, int startOffset, int endOffset) {}
```

…but missed four `new TermEntry(...)` construction sites in `StreamingFieldPostings{9,10}.java` (the streaming postings cursors landed in earlier commits on this branch). Those sites still passed the old 3-arg form, so the branch fails to compile:

```
error: constructor TermEntry in record TermEntry cannot be applied to given types;
  required: String,int,int,int
  found:    String,int,int
```

This patch updates each site to pass the absolute Lucene position alongside the offsets, so `LuceneLeafReader.splitByPositionGap` can recover array-element boundaries via `position_increment_gap` as intended.

### Source of `position` per call site

| File | Line | Source of `position` |
|---|---|---|
| `StreamingFieldPostings10.java` | 175 | local `pos` (assigned from `c.postings.nextPosition()` above) |
| `StreamingFieldPostings10.java` | 202 | `po[0]` from the `int[] posOffsets` layout `{pos, startOff, endOff, collectedIdx}` (line 174). The previous code used `po[1]`/`po[2]` only — `po[0]` was already there but unconsumed. |
| `StreamingFieldPostings9.java` | both branches of `sortAndBuildResult` | unpacked from the existing packed `scratchSortKey` per the documented encoding `sortKey[i] = (pos << 32) \| (i & 0xFFFFFFFFL)` — `(int) (key >>> 32)` is the position, `(int) key` is the index. |

The v9 fix preserves the existing primitive-long-sort fast path (JDK 21 vectorized intrinsic) — no parallel `scratchPos[]` array, no boxing.

### Verification

```
./gradlew :SearchSnapshotExtractor:compileJava \
          :SearchSnapshotExtractor:compileLucene9Java \
          :SearchSnapshotExtractor:compileLucene10Java
BUILD SUCCESSFUL
```

### Scope

Compile-only fix. No behavior change for the 3-arg call sites that were already correct (`SidecarReader.java`). The new positions feed into the existing `splitByPositionGap` logic in `LuceneLeafReader`, exercising the per-element reconstruction path that `5907211b` introduced.
