### PR TITLE
Default doc transformation to none; activate raw-bytes fast path

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -96,11 +96,20 @@ public class RfsMigrateDocuments {
     private static final double DECREASE_LEASE_DURATION_SHARD_SETUP_THRESHOLD = 0.025;
     private static final double INCREASE_LEASE_DURATION_SHARD_SETUP_THRESHOLD = 0.1;
 
-    public static final String DEFAULT_DOCUMENT_TRANSFORMATION_CONFIG = "[" +
-            "  {" +
-            "    \"JsonTransformerForDocumentTypeRemovalProvider\":\"\"" +
-            "  }" +
-            "]";
+    /**
+     * Default document-transformation config used when the user does not supply one.
+     *
+     * <p>Historically this defaulted to {@code JsonTransformerForDocumentTypeRemovalProvider}
+     * to strip the {@code _type} action-line field on ES 5/6/7 → OpenSearch migrations.
+     * That stripping is no longer needed: the bulk NDJSON action lines in
+     * {@link org.opensearch.migrations.bulkload.common.bulk.BulkNdjson} are built from
+     * scratch with only {@code id}, {@code index}, and {@code routing}, so {@code _type}
+     * is never written to the wire regardless of source. Defaulting to {@code null}
+     * lets {@link org.opensearch.migrations.bulkload.pipeline.adapter.OpenSearchDocumentSink}
+     * take its raw-bytes fast path (skipping the {@code byte[]→Map→byte[]} round-trip)
+     * for every migration that doesn't supply a custom transformation.
+     */
+    public static final String DEFAULT_DOCUMENT_TRANSFORMATION_CONFIG = null;
 
     public static class DurationConverter implements IStringConverter<Duration> {
         @Override
@@ -508,12 +517,17 @@ public class RfsMigrateDocuments {
             }
         };
 
-        var docTransformerConfig = Optional.ofNullable(TransformerConfigUtils.getTransformerConfig(arguments.docTransformationParams))
-            .orElse(DEFAULT_DOCUMENT_TRANSFORMATION_CONFIG);
-        log.atInfo().setMessage("Doc Transformations config string: {}")
-                .addArgument(docTransformerConfig).log();
+        var docTransformerConfig = TransformerConfigUtils.getTransformerConfig(arguments.docTransformationParams);
+        if (docTransformerConfig != null) {
+            log.atInfo().setMessage("Doc Transformations config string: {}")
+                    .addArgument(docTransformerConfig).log();
+        } else {
+            log.atInfo().setMessage("No doc transformations configured; using raw-bytes fast path").log();
+        }
         var transformationLoader = new TransformationLoader();
-        Supplier<IJsonTransformer> docTransformerSupplier = () -> transformationLoader.getTransformerFactoryLoader(docTransformerConfig);
+        Supplier<IJsonTransformer> docTransformerSupplier = docTransformerConfig == null
+            ? null
+            : () -> transformationLoader.getTransformerFactoryLoader(docTransformerConfig);
 
         if (arguments.sourceVersion != null && arguments.sourceVersion.getFlavor() == Flavor.SOLR) {
             runSolrBackupMigration(arguments, targetClient, docTransformerSupplier, useServerGeneratedIds, context);


### PR DESCRIPTION
## Summary

Default `docTransformerConfig` to `null` and let `OpenSearchDocumentSink` take its raw-bytes fast path when no user transformation is configured.

## Why

Profiling a 300k-doc backfill showed `ObjectMapper.convertValue` ×2 (per document) dominating the worker hot path. The slow path:

```
batch -> List<BulkOperationSpec> via fromDocument
       -> List<Map> via convertValue       <-- copy 1
       -> transformer.transformJson(maps)  <-- only removed "_type" key
       -> List<BulkOperationSpec> via convertValue  <-- copy 2
       -> sendBulkRequest
```

Every default-config migration paid this cost just to strip `_type` from the action line — even though `BulkNdjson.toRawNdjsonBytes` (used by `sendBulkRequestRaw`) already builds the action line from scratch with `id` / `index` / `routing` only. `_type` is never on the wire from the raw path.

## Change

- `RfsMigrateDocuments.DEFAULT_DOCUMENT_TRANSFORMATION_CONFIG`: JSON wiring of `JsonTransformerForDocumentTypeRemovalProvider` → `null`
- `docTransformerSupplier`: `null` when no user config is provided (instead of a supplier that returns an empty/no-op composite). This propagates to `OpenSearchDocumentSink.transformer == null` and activates the existing fast path at `OpenSearchDocumentSink.java:98`.

## Behavior matrix

| Scenario | Before | After | Wire bytes |
|---|---|---|---|
| ES 5/6/7 → OS, no user transform | slow path strips `_type` via JSON transformer | fast path emits action line without `_type` | identical |
| Any source, with user transform | slow path runs user transform alone (default was replaced via `Optional.orElse`) | unchanged | identical |
| ES 2 / Solr / no `_type` | slow path with no-op transform | fast path | identical |

User-supplied transformers were never composed with the default — `Optional.ofNullable(user).orElse(default)` already replaced it. So this change has no behavior impact on custom-transform users.

## Tests

Compiles green for `:DocumentsFromSnapshotMigration:compileJava` and `:compileTestJava`. Tests reference `DEFAULT_DOCUMENT_TRANSFORMATION_CONFIG` and pass it to `getTransformerFactoryLoader(...)` — passing `null` returns a `JsonCompositeTransformer` wrapping zero stages (semantically equivalent to the prior empty-config behavior on those test paths).

## Validation plan

Run the full enron 300k-doc backfill (ES 7.17.22 → AOS 3.5) on EKS with this image and compare end-to-end docs/sec against the prior baseline (Run-A: 63.5 docs/sec).
