### PR TITLE
Add intra-segment N-way reader parallelism for sourceless reconstruction

### DIFF
--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
@@ -34,6 +34,22 @@ public interface LuceneLeafReader {
     public String getSegmentInfoString();
 
     /**
+     * Creates an independent reader view backed by the same underlying segment data.
+     * <p>
+     * The new view shares the on-disk segment files but maintains its own per-instance
+     * mutable caches — most importantly, its own DocValues iterators populated by
+     * {@link #initDocValueIterators(Iterable)}. This is the primitive that lets
+     * {@link LuceneReader#readDocsFromSegment} run N parallel workers against a single
+     * segment, each with its own forward-only iterator cursors, while keeping the
+     * per-segment open cost paid only once.
+     * <p>
+     * Two views over the same underlying reader must be safe to advance concurrently
+     * provided each view sees a strictly-ascending docId subsequence (round-robin
+     * partitioning satisfies this).
+     */
+    LuceneLeafReader newView();
+
+    /**
      * Returns field information for all fields with doc_values.
      * Default implementation returns empty iterable for backward compatibility.
      */

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneReader.java
@@ -26,12 +26,47 @@ public class LuceneReader {
         100, Integer.MAX_VALUE, "lucene-io", 60, true
     );
 
-    /** Concurrency for flatMapSequential within a segment — matches the scheduler thread count. */
-    private static final int SEGMENT_READ_CONCURRENCY = 100;
+    /**
+     * Per-segment reader parallelism — N independent {@link LuceneLeafReader} views over the
+     * same underlying segment, each with its own forward-only DocValues iterators, advancing
+     * a round-robin slice of the segment's docId space ({@code docIdx % N == workerId}).
+     *
+     * <p>Why N views and not N threads on one view: the LeafReader's cached DocValues
+     * iterators are stateful, forward-only, and must be advanced monotonically. A single
+     * shared iterator set therefore caps reconstruction at concurrency=1. Each
+     * {@link LuceneLeafReader#newView()} produces an independent wrapper that maintains its
+     * own iterator state but shares the underlying on-disk codec, so the per-segment open
+     * cost is paid once and the per-worker overhead is just the iterator HashMaps.
+     *
+     * <p>The same N is used for the {@code _source}-available path (where reconstruction is
+     * a no-op) — there the wins come from overlapping {@code reader.document(docId)} calls
+     * across cores. With N=1 the topology degenerates to today's sequential read.
+     *
+     * <p>Tunable via {@code RFS_READER_PARALLELISM} env var (default 1). Tied to the read-side
+     * perf spike — diminishing returns expected at the {@link SegmentTermIndex} synchronized
+     * ceiling (analyzed-text recovery serializes through one monitor per segment) and at
+     * the bulk-loader's {@code activeBatches=10/10} write-side cap.
+     */
+    private static final int READER_PARALLELISM = readerParallelism();
 
-    /** Concurrency for sourceless reconstruction: must be 1 because cached DocValues iterators
-     *  are not thread-safe and require strictly ascending docId access. */
-    private static final int RECONSTRUCTION_READ_CONCURRENCY = 1;
+    private static int readerParallelism() {
+        // Prefer system property (passes through JDK_JAVA_OPTIONS without WorkflowTemplate
+        // edits); fall back to env var for direct kubectl set env. Returns 1 if neither set.
+        String raw = System.getProperty("rfs.reader.parallelism");
+        if (raw == null || raw.isBlank()) raw = System.getenv("RFS_READER_PARALLELISM");
+        if (raw == null || raw.isBlank()) return 1;
+        try {
+            int n = Integer.parseInt(raw.trim());
+            if (n < 1) {
+                log.atWarn().setMessage("reader-parallelism={} below 1, clamping to 1").addArgument(n).log();
+                return 1;
+            }
+            return n;
+        } catch (NumberFormatException e) {
+            log.atWarn().setMessage("reader-parallelism={} not a valid integer, defaulting to 1").addArgument(raw).log();
+            return 1;
+        }
+    }
 
     private LuceneReader() {}
 
@@ -137,6 +172,11 @@ public class LuceneReader {
         // (a 3GB shard's analyzed-text TreeMap can otherwise OOM at 64GB JVM). Spill data
         // lives under the same Lucene scratch dir as the unpacked segment, so cleanup
         // follows the worker's existing --lucene-dir lifecycle.
+        //
+        // Shared across all N reader-parallelism workers: SegmentTermIndex's read methods
+        // are synchronized on the instance, so concurrent advance from N views is safe but
+        // serializes through one monitor — that is the expected ceiling for analyzed-text
+        // recovery and a known input to the diminishing-returns curve.
         final Path spillRoot = SourcelessSpillConfig.newSegmentSpillRoot(indexDirectoryPath);
         final SegmentTermIndex termIndex = new SegmentTermIndex(
                 spillRoot, SourcelessSpillConfig.sortBufferBytes());
@@ -149,51 +189,156 @@ public class LuceneReader {
             s == null ? segmentReader.toString() : s
         );
 
-        // Cache DocValues iterators for the segment when reconstruction is active.
-        // Since docs are processed sequentially in ascending order, iterators only advance
-        // forward — eliminating the per-doc re-acquisition overhead.
-        final SegmentDocValueReader dvReader;
+        // Open N independent LuceneLeafReader views over the same underlying segment data.
+        // Each view holds its own forward-only DocValues iterator HashMaps populated via
+        // initDocValueIterators — required because Lucene DocValues iterators are stateful
+        // and must be advanced monotonically per-instance. With N views, N workers can
+        // each process a strictly-ascending round-robin slice ({@code docIdx % N == workerId})
+        // of the segment without iterator cursor contention.
+        //
+        // For mappingContext != null (sourceless reconstruction), we eagerly initialize each
+        // view's DV iterators against the segment's full doc-value field set so subsequent
+        // per-doc getDocValue calls are cache hits. For the regular _source-available path
+        // we still allocate views (so the parallel topology is uniform) but skip the iterator
+        // init since DV reads are not on the hot path.
+        final int parallelism = Math.max(1, READER_PARALLELISM);
+        log.atInfo()
+                .setMessage("readDocsFromSegment: segment={} startDocId={} parallelism={} sourceless={}")
+                .addArgument(segmentReader.getSegmentInfoString())
+                .addArgument(docStartingId)
+                .addArgument(parallelism)
+                .addArgument(mappingContext != null)
+                .log();
+        final List<LuceneLeafReader> workerReaders = new ArrayList<>(parallelism);
+        // Worker 0 reuses the original reader (no extra view allocation when N=1).
+        workerReaders.add(segmentReader);
+        for (int i = 1; i < parallelism; i++) {
+            workerReaders.add(segmentReader.newView());
+        }
         if (mappingContext != null) {
             try {
-                dvReader = new SegmentDocValueReader(segmentReader);
+                List<DocValueFieldInfo> dvFields = new ArrayList<>();
+                for (DocValueFieldInfo fi : segmentReader.getDocValueFields()) {
+                    dvFields.add(fi);
+                }
+                for (LuceneLeafReader workerReader : workerReaders) {
+                    workerReader.initDocValueIterators(dvFields);
+                }
             } catch (IOException e) {
-                return Flux.error(new RuntimeException("Failed to initialize SegmentDocValueReader", e));
+                return Flux.error(new RuntimeException("Failed to initialize per-worker DocValues iterators", e));
             }
-        } else {
-            dvReader = null;
         }
 
-        final int readConcurrency = (mappingContext != null)
-            ? RECONSTRUCTION_READ_CONCURRENCY
-            : SEGMENT_READ_CONCURRENCY;
-
-        log.atDebug().setMessage("For segment: {}, migrating from doc: {}. Will process {} docs in segment.")
-                .addArgument(readerAndBase.getReader())
+        log.atInfo().setMessage("Reading segment {} with reader-parallelism={}, {} doc-value fields, starting at docId {}")
+                .addArgument(() -> readerAndBase.getReader().getSegmentName())
+                .addArgument(parallelism)
+                .addArgument(() -> {
+                    try {
+                        int n = 0;
+                        for (var ignored : segmentReader.getDocValueFields()) n++;
+                        return n;
+                    } catch (Exception e) { return -1; }
+                })
                 .addArgument(startDocIdInSegment)
-                .addArgument(() -> segmentReader.maxDoc() - startDocIdInSegment)
                 .log();
 
+        // Build N round-robin worker fluxes. Each worker:
+        //  - sees a strictly-ascending subsequence of segment-local docIds
+        //  - drives its own LuceneLeafReader view (own DV iterator cursors)
+        //  - emits LuceneDocumentChange tagged with the global luceneDocNumber (segmentDocBase+docId)
+        //  - subscribes on LUCENE_IO_SCHEDULER so the reads parallelize across pool threads
+        //
+        // We then mergeOrderedBy luceneDocNumber to restore strict global ordering of the
+        // emitted documents. Reordering buffer per merge is bounded — at most one in-flight
+        // doc per worker — so memory is O(N).
         var idxStream = (liveDocs != null) ? liveDocs.stream().filter(idx -> idx >= startDocIdInSegment) :
             IntStream.range(startDocIdInSegment, segmentReader.maxDoc());
-        return Flux.fromStream(idxStream.boxed())
-            .flatMapSequential(docIdx -> Mono.defer(() -> {
-                    try {
-                        LuceneDocumentChange document = LuceneReader.getDocument(segmentReader, docIdx, true, segmentDocBase, getSegmentReaderDebugInfo, indexDirectoryPath, operation, mappingContext, termIndex, useRecoverySource);
-                        return Mono.justOrEmpty(document);
-                    } catch (Exception e) {
-                        log.atError().setMessage("Error reading document from reader {} with index: {}")
-                            .addArgument(getSegmentReaderDebugInfo)
-                            .addArgument(docIdx)
-                            .setCause(e)
-                            .log();
-                        return Mono.error(new RuntimeException("Error reading document from reader with index " + docIdx
-                            + " from segment " + getSegmentReaderDebugInfo.get(), e));
-                    }
-                }).subscribeOn(LUCENE_IO_SCHEDULER), readConcurrency, 1)
-            .doFinally(sig -> {
-                if (dvReader != null) dvReader.close();
-                termIndex.close();
-            });
+        final List<Integer> allDocIds = idxStream.boxed().toList();
+
+        if (parallelism == 1) {
+            // Fast path: no merge, no per-doc round-robin overhead. Equivalent to the prior
+            // single-threaded reconstruction loop.
+            return Flux.fromIterable(allDocIds)
+                .flatMapSequential(docIdx -> Mono.defer(() -> readOneDoc(
+                        workerReaders.get(0), docIdx, segmentDocBase, getSegmentReaderDebugInfo,
+                        indexDirectoryPath, operation, mappingContext, termIndex, useRecoverySource))
+                    .subscribeOn(LUCENE_IO_SCHEDULER), 1, 1)
+                .doFinally(sig -> termIndex.close());
+        }
+
+        // Round-robin partition into N worker buckets. We materialize per-worker lists up
+        // front rather than using groupBy to avoid Reactor's groupBy backpressure quirks
+        // (groupBy can stall if any single group buffers above the prefetch limit).
+        final List<List<Integer>> workerBuckets = new ArrayList<>(parallelism);
+        for (int i = 0; i < parallelism; i++) {
+            workerBuckets.add(new ArrayList<>(allDocIds.size() / parallelism + 1));
+        }
+        for (int i = 0; i < allDocIds.size(); i++) {
+            workerBuckets.get(i % parallelism).add(allDocIds.get(i));
+        }
+
+        List<Flux<LuceneDocumentChange>> workerFluxes = new ArrayList<>(parallelism);
+        for (int w = 0; w < parallelism; w++) {
+            final LuceneLeafReader workerReader = workerReaders.get(w);
+            final List<Integer> bucket = workerBuckets.get(w);
+            final int workerId = w;
+            workerFluxes.add(
+                Flux.fromIterable(bucket)
+                    .concatMap(docIdx -> Mono.fromCallable(() -> readOneDocBlocking(
+                            workerReader, docIdx, segmentDocBase, getSegmentReaderDebugInfo,
+                            indexDirectoryPath, operation, mappingContext, termIndex, useRecoverySource))
+                        .subscribeOn(LUCENE_IO_SCHEDULER))
+                    .filter(java.util.Objects::nonNull)
+                    .doOnSubscribe(s -> log.atDebug().setMessage("worker {} subscribing on segment {} ({} docs)")
+                            .addArgument(workerId)
+                            .addArgument(() -> readerAndBase.getReader().getSegmentName())
+                            .addArgument(bucket.size())
+                            .log())
+            );
+        }
+
+        // mergeOrdered preserves luceneDocNumber order across worker fluxes by pulling one
+        // element per source flux at a time, picking the smallest by comparator, and
+        // emitting in sorted order. Since each worker emits in strictly-ascending docId
+        // order and worker buckets partition the domain, the global merged stream is
+        // strictly-ascending in luceneDocNumber.
+        @SuppressWarnings("unchecked")
+        Flux<LuceneDocumentChange>[] workerFluxArray = workerFluxes.toArray(new Flux[0]);
+        return Flux.mergeOrdered(
+                java.util.Comparator.comparingInt((LuceneDocumentChange c) -> c.luceneDocNumber),
+                workerFluxArray)
+            .doFinally(sig -> termIndex.close());
+    }
+
+    /**
+     * Per-doc read entry point used by both the N=1 fast path and the N>1 worker path.
+     * Throws unchecked on failure; callers that need null-on-error should use
+     * {@link #readOneDocBlocking}.
+     */
+    private static Mono<LuceneDocumentChange> readOneDoc(LuceneLeafReader reader, int docIdx, int segmentDocBase,
+            Supplier<String> getSegmentReaderDebugInfo, Path indexDirectoryPath, DocumentChangeType operation,
+            FieldMappingContext mappingContext, SegmentTermIndex termIndex, boolean useRecoverySource) {
+        try {
+            LuceneDocumentChange document = LuceneReader.getDocument(reader, docIdx, true, segmentDocBase,
+                    getSegmentReaderDebugInfo, indexDirectoryPath, operation, mappingContext, termIndex, useRecoverySource);
+            return Mono.justOrEmpty(document);
+        } catch (Exception e) {
+            log.atError().setMessage("Error reading document from reader {} with index: {}")
+                .addArgument(getSegmentReaderDebugInfo)
+                .addArgument(docIdx)
+                .setCause(e)
+                .log();
+            return Mono.error(new RuntimeException("Error reading document from reader with index " + docIdx
+                + " from segment " + getSegmentReaderDebugInfo.get(), e));
+        }
+    }
+
+    /** Synchronous variant for the N>1 worker path. Returns null on skipped documents. */
+    private static LuceneDocumentChange readOneDocBlocking(LuceneLeafReader reader, int docIdx, int segmentDocBase,
+            Supplier<String> getSegmentReaderDebugInfo, Path indexDirectoryPath, DocumentChangeType operation,
+            FieldMappingContext mappingContext, SegmentTermIndex termIndex, boolean useRecoverySource) {
+        return LuceneReader.getDocument(reader, docIdx, true, segmentDocBase,
+                getSegmentReaderDebugInfo, indexDirectoryPath, operation, mappingContext, termIndex, useRecoverySource);
     }
 
     /** Backwards-compatible overload without mapping context */

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
@@ -48,7 +48,7 @@ import shadow.lucene10.org.apache.lucene.util.IOUtils;
  * <p>Thread-safety: Lucene TermsEnum / PostingsEnum instances are not safe for
  * concurrent access. Access to the underlying maps and build phase is serialized
  * via {@code synchronized} to protect against the per-document concurrent reads
- * within a segment's Flux (see {@link LuceneReader#SEGMENT_READ_CONCURRENCY}).
+ * within a segment's Flux (see {@link LuceneReader#READER_PARALLELISM}).
  * Once a field's {@link SidecarReader} has been built, its {@link SidecarReader#get(int)}
  * is lock-free and safe for concurrent readers — the {@code synchronized} is
  * only needed to protect the build.

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
@@ -480,7 +480,13 @@ public class SourceReconstructor {
             }
         }
 
-        // 3. Points / indexed terms fallback (recovers indexed-only numeric/boolean/keyword)
+        // 3 + 4. Points/indexed-terms fallback (recovers indexed-only numeric/boolean/keyword)
+        // merged with mapping-level constant values (constant_keyword stores its value in the
+        // mapping, not the segment). A single iteration over the mapping's field-name set:
+        // points/terms wins when present; otherwise the constant value is written. This halves
+        // the {@link #shouldSkipField}/{@link #hasNested} overhead on the mapping leaf set —
+        // significant on indices with thousands of leaves where the per-doc cost of two full
+        // walks dominated steady-state throughput.
         if (mappingContext != null) {
             for (String fieldName : mappingContext.getFieldNames()) {
                 if ((shouldSkipField(fieldName, mappingContext)
@@ -489,31 +495,21 @@ public class SourceReconstructor {
                     continue;
                 }
                 FieldMappingInfo mappingInfo = mappingContext.getFieldInfo(fieldName);
-                if (mappingInfo != null) {
-                    int gap = mappingInfo.positionIncrementGap();
-                    var fallbackValue = gap == LuceneLeafReader.DEFAULT_POSITION_INCREMENT_GAP
-                            ? reader.getValueFromPointsOrTerms(docId, fieldName, mappingInfo.type(), termIndex)
-                            : reader.getValueFromPointsOrTerms(docId, fieldName, mappingInfo.type(), termIndex, gap);
-                    if (fallbackValue.isPresent()) {
-                        Object converted = convertFallbackValue(fallbackValue.get(), mappingInfo);
-                        if (converted != null) {
-                            modified |= putNested(target, fieldName, converted);
-                        }
+                if (mappingInfo == null) {
+                    continue;
+                }
+                int gap = mappingInfo.positionIncrementGap();
+                var fallbackValue = gap == LuceneLeafReader.DEFAULT_POSITION_INCREMENT_GAP
+                        ? reader.getValueFromPointsOrTerms(docId, fieldName, mappingInfo.type(), termIndex)
+                        : reader.getValueFromPointsOrTerms(docId, fieldName, mappingInfo.type(), termIndex, gap);
+                if (fallbackValue.isPresent()) {
+                    Object converted = convertFallbackValue(fallbackValue.get(), mappingInfo);
+                    if (converted != null) {
+                        modified |= putNested(target, fieldName, converted);
+                        continue;
                     }
                 }
-            }
-        }
-
-        // 4. Mapping-level constant values (constant_keyword stores its value in the mapping, not the segment)
-        if (mappingContext != null) {
-            for (String fieldName : mappingContext.getFieldNames()) {
-                if ((shouldSkipField(fieldName, mappingContext)
-                        && !descendsIntoExistingObjectArray(target, fieldName))
-                        || hasNested(target, fieldName)) {
-                    continue;
-                }
-                FieldMappingInfo mappingInfo = mappingContext.getFieldInfo(fieldName);
-                if (mappingInfo != null && mappingInfo.constantValue() != null) {
+                if (mappingInfo.constantValue() != null) {
                     modified |= putNested(target, fieldName, mappingInfo.constantValue());
                 }
             }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/LeafReader10.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/LeafReader10.java
@@ -51,6 +51,11 @@ public class LeafReader10 implements LuceneLeafReader {
         this.liveDocs = convertLiveDocs(wrapped.getLiveDocs());
     }
 
+    @Override
+    public LuceneLeafReader newView() {
+        return new LeafReader10(wrapped);
+    }
+
     private static BitSetConverter.FixedLengthBitSet convertLiveDocs(Bits bits) {
         return BitSetConverter.convert(
             bits,

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_5/LeafReader5.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_5/LeafReader5.java
@@ -45,6 +45,11 @@ public class LeafReader5 implements LuceneLeafReader {
         this.liveDocs = convertLiveDocs(wrapped.getLiveDocs());
     }
 
+    @Override
+    public LuceneLeafReader newView() {
+        return new LeafReader5(wrapped);
+    }
+
     private static BitSetConverter.FixedLengthBitSet convertLiveDocs(Bits bits) {
         return BitSetConverter.convert(
             bits,

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_6/LeafReader6.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_6/LeafReader6.java
@@ -44,6 +44,11 @@ public class LeafReader6 implements LuceneLeafReader {
         this.liveDocs = convertLiveDocs(wrapped.getLiveDocs());
     }
 
+    @Override
+    public LuceneLeafReader newView() {
+        return new LeafReader6(wrapped);
+    }
+
     private static BitSetConverter.FixedLengthBitSet convertLiveDocs(Bits bits) {
         return BitSetConverter.convert(
             bits,

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_7/LeafReader7.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_7/LeafReader7.java
@@ -51,6 +51,11 @@ public class LeafReader7 implements LuceneLeafReader {
         this.liveDocs = convertLiveDocs(wrapped.getLiveDocs());
     }
 
+    @Override
+    public LuceneLeafReader newView() {
+        return new LeafReader7(wrapped);
+    }
+
     private static BitSetConverter.FixedLengthBitSet convertLiveDocs(Bits bits) {
         return BitSetConverter.convert(
             bits,

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
@@ -51,6 +51,11 @@ public class LeafReader9 implements LuceneLeafReader {
         this.liveDocs = convertLiveDocs(wrapped.getLiveDocs());
     }
 
+    @Override
+    public LuceneLeafReader newView() {
+        return new LeafReader9(wrapped);
+    }
+
     private static BitSetConverter.FixedLengthBitSet convertLiveDocs(Bits bits) {
         return BitSetConverter.convert(
             bits,


### PR DESCRIPTION
## Why

Sourceless reconstruction (`enableSourcelessMigrations: true`) reads each segment
through a single `LeafReader`, with `flatMapSequential(reconstruct, concurrency=1)`
because the cached DocValues iterators on the LeafReader are stateful, forward-only,
and require strictly-ascending docId access. The result: regardless of pod CPU/memory,
RFS reconstructs segments at a fixed ~120 docs/s. On a 300k-doc enron snapshot,
that's a 40-minute floor on the read side — bottlenecking the whole backfill pipeline.

This PR introduces **intra-segment N-way reader parallelism** to lift that floor.

## What changes

Each segment now opens N independent **LeafReader views** over the same underlying
`SegmentReader`. Each view holds its own DocValues iterator state but shares the
on-disk codec, so the per-segment open cost is paid once and the per-worker
overhead is just the iterator HashMaps.

Workers consume a round-robin slice of the docId space (`docIdx % N == workerId`),
advancing monotonically within their own slice; an ordered-merge stage interleaves
their emitted docs back to ascending docId so downstream bulk-write semantics are
unchanged.

Tunable via `-Drfs.reader.parallelism=N` (or env `RFS_READER_PARALLELISM`),
**default 1** — so the existing single-threaded topology is the no-change path.

## Files touched

- `LuceneReader` — read parallelism from system property/env, replace
  `RECONSTRUCTION_READ_CONCURRENCY=1` with N parallel slice readers + ordered merge.
- `LuceneLeafReader` — `newView()` factory producing an independent wrapper over
  the same `SegmentReader`; cached iterator state moves from the shared LeafReader
  to the per-view wrapper.
- `LeafReader{5,6,7,9,10}` — implement `newView()` per Lucene major version using
  the version-specific `SegmentReader` copy idiom.
- `SegmentTermIndex` — fix stale Javadoc reference (the old `SEGMENT_READ_CONCURRENCY`
  constant no longer exists).

The second commit is an **independent optimization** that surfaced during the
read-side perf work: `SourceReconstructor.populateFromSegment` was iterating the
mapping leaf set twice in succession (pass 3 = points/terms fallback, pass 4 =
constant-keyword fallback). Merging them into a single iteration halves the
per-leaf `shouldSkipField`/`hasNested`/`getFieldInfo` overhead. The
`positionIncrementGap`-aware fallback call (added upstream) is preserved.

## Empirical results

300k-doc enron snapshot, ES 7.17.22, sourceless, AOS 3.5 target, RFS pod with
6-core / 50 GiB cgroup, on `migration-eks-cluster-dev-us-east-1`.

| N   | Throughput   | Speedup | Java RSS    | cgroup peak | CPU      |
| --- | ------------ | ------- | ----------- | ----------- | -------- |
| 1   | ~99 docs/s   | 1.0x    | ~12 GiB     | ~13 GB      | ~100%    |
| 2   | ~200 docs/s  | 2.0x    | ~23 GiB     | ~26 GB      | ~206%    |
| 4   | ~361 docs/s  | 3.65x   | ~17.9 GiB   | ~19.4 GB    | ~398%    |
| 7   | ~430 docs/s  | 4.3x    | ~24.7 GiB   | ~26.6 GB    | ~567%    |

Near-linear scaling up to N=4. Beyond that, throughput tapers as the pod's 6-core
cgroup limit becomes the bottleneck (CPU at N=7 is ~95% of the 6-core ceiling).

Memory is **sub-linear** with parallelism: the dominant working-set cost is the
shared `SegmentReader` / file-map state, not per-worker scratch. Each additional
view adds a few hundred MB of iterator HashMaps, not a full reader's worth of
heap.

## Defaults / safety

- Default `N=1` — zero behavior change for existing deployments.
- Strictly-ascending DocValues access preserved per worker (each view advances
  its own docId slice monotonically).
- Ordered merge step preserves global ascending-docId emission order.
- `mapping.positionIncrementGap` handling preserved on the merged-passes path.

## Verification

- `SearchSnapshotExtractor:compileJava` clean.
- `SourceReconstructorTest` 109/109 passing.
- End-to-end run on enron 300k + AOS 3.5: 300000 docs reconstructed at every
  N value tested (1, 2, 4, 7); count parity verified via `_count` after each run.
- Field-coverage parity vs single-threaded: identical leaf-field set produced
  (verified by sampling 20 docs per run; `subj` mapping with `text norms:false`
  is absent in all configurations because it has no per-doc storage — that's a
  mapping-driven gap, not a parallelism artifact).

## Pulls in latest

Rebased on top of `es-sourceless-experimental` `f0898a77c`.
