### PR TITLE
deploy: kill ExecCommandRunner subprocess tree on ctx cancel (stacked on #3008)

### DIFF
--- a/migrationAssistantTUI/internal/feature/deploy/real.go
+++ b/migrationAssistantTUI/internal/feature/deploy/real.go
@@ -7,7 +7,17 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"time"
 )
+
+// processGroupKillWaitDelay bounds how long cmd.Wait may block after
+// Cancel has fired. If a grandchild still holds the inherited stdout
+// pipe, the io-copy goroutine inside os/exec would hang forever; this
+// backstop forcibly closes the pipe and surfaces the ctx error. 2s is
+// generous enough for an honest fast-exit and tight enough to keep the
+// CI ContextCancelKillsProcess assertion (<2s elapsed) realistic when
+// composed with the immediate pgroup-kill below.
+const processGroupKillWaitDelay = 2 * time.Second
 
 // ExecStep is one subprocess invocation a Plan resolves to.
 //
@@ -200,15 +210,41 @@ type ExecCommandRunner struct{}
 
 // Run executes (cmd, args) under ctx, streaming merged stdout/stderr
 // lines through onLine. Returns nil on exit 0; otherwise returns the
-// underlying error from cmd.Wait. ctx cancellation propagates to the
-// process via exec.CommandContext.
+// underlying error from cmd.Wait. ctx cancellation propagates by
+// SIGKILL'ing the whole process group, not just the leader — see
+// configureProcessGroup for the rationale (process-tree leak via
+// inherited stdout pipe held open by orphaned grandchildren).
 func (ExecCommandRunner) Run(ctx context.Context, _ string, cmd string, args []string, onLine func(string)) error {
+	// We use exec.CommandContext so Cmd.Start accepts our custom
+	// Cancel (Go enforces that Cancel is only valid on
+	// CommandContext-created commands). We then OVERRIDE the default
+	// Cancel (which Kills only the leader) with one that targets the
+	// whole process group. The default Cancel only Kill()s the leader;
+	// if the script backgrounds a grandchild (common in shell wrappers
+	// around helm/kubectl), the grandchild inherits stdout and keeps
+	// the pipe open, blocking cmd.Wait until the grandchild's natural
+	// exit. The pgroup-kill + WaitDelay combo breaks that liveness
+	// chain. See real_exec_pgroup_test.go for the regression guard.
 	c := exec.CommandContext(ctx, cmd, args...)
+	configureProcessGroup(c) // platform-specific: Setpgid on Unix, no-op elsewhere
+
 	stdout, err := c.StdoutPipe()
 	if err != nil {
 		return err
 	}
 	c.Stderr = c.Stdout // merge — single line stream simplifies the UI
+
+	// Custom Cancel: kill the whole process group, not just the leader.
+	// This is the real fix; WaitDelay below is only a backstop.
+	// CommandContext sets up the ctx→Cancel bridge for us; we just
+	// need to override Cancel before Start().
+	c.Cancel = func() error { return killProcessGroup(c) }
+	// WaitDelay backstop: if Cancel fired but cmd.Wait is still blocked
+	// on an inherited FD (rare after pgroup-kill but possible if the
+	// kernel hasn't reaped yet), force-close pipes and let Wait return
+	// after this delay. Without it, cmd.Wait could hang indefinitely.
+	c.WaitDelay = processGroupKillWaitDelay
+
 	if err := c.Start(); err != nil {
 		return err
 	}
@@ -229,6 +265,12 @@ func (ExecCommandRunner) Run(ctx context.Context, _ string, cmd string, args []s
 	// downstream of the process exiting anyway, and Wait() has the
 	// authoritative status.
 	if err := c.Wait(); err != nil {
+		// If ctx was cancelled, prefer the ctx error over the
+		// "signal: killed" wait error — it's more informative for
+		// callers.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return err
 	}
 	if scanErr := scanner.Err(); scanErr != nil && !errors.Is(scanErr, io.EOF) {

--- a/migrationAssistantTUI/internal/feature/deploy/real_exec_pgroup_test.go
+++ b/migrationAssistantTUI/internal/feature/deploy/real_exec_pgroup_test.go
@@ -1,0 +1,123 @@
+package deploy_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/opensearch-project/opensearch-migrations/migrationAssistantTUI/internal/feature/deploy"
+)
+
+// TestExecCommandRunner_Run_KillsBackgroundedGrandchild captures the
+// dash-vs-bash CI failure mode: a process tree where the immediate child
+// (sh) backgrounds a grandchild (sleep). On `exec.CommandContext` cancel,
+// the default Cancel only SIGKILLs the leader; the orphaned grandchild
+// keeps the inherited stdout pipe open, blocking cmd.Wait() until the
+// natural sleep duration (5s observed in CI). The fix sets Setpgid so we
+// can identify the pgroup, replaces Cancel with a pgroup-kill, and sets
+// WaitDelay as a backstop. This test asserts the *outcome*: the
+// grandchild PID disappears within 2s of cancel — independent of which
+// shell `/bin/sh` resolves to.
+//
+// We discover the grandchild PID by having the script write its own
+// PID to a file in tmpdir before sleeping, then checking /proc/<pid>
+// after cancel.
+func TestExecCommandRunner_Run_KillsBackgroundedGrandchild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/bin/sh not available on windows")
+	}
+	if runtime.GOOS != "linux" {
+		// /proc/<pid> existence check is Linux-only. macOS has its own
+		// process model; the production fix still applies, but we
+		// can't observe it the same way. The original elapsed-time
+		// assertion in TestExecCommandRunner_Run_ContextCancelKillsProcess
+		// covers macOS.
+		t.Skip("grandchild-pid observation requires /proc")
+	}
+
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "grandchild.pid")
+
+	// The script: spawn a backgrounded `sh -c` grandchild that records
+	// its own pid via $$ (reliable across bash and dash) and then
+	// sleeps long. The leader execs into a foreground sleep so the
+	// leader pid is well-defined. The grandchild stays in the leader's
+	// process group (no setsid) — that's the exact dash topology that
+	// triggered the CI failure: SIGKILL on the leader leaves the
+	// grandchild orphaned but still in the same pgroup, holding the
+	// inherited stdout pipe.
+	script := `sh -c 'echo $$ > ` + pidFile + `; sleep 30' & exec sleep 30`
+
+	r := deploy.ExecCommandRunner{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- r.Run(ctx, "phase-x", "/bin/sh", []string{"-c", script}, func(string) {})
+	}()
+
+	// Wait for the grandchild to record its PID. Up to 3s — the
+	// `sh -c` grandchild needs to fork+exec+open file before we can
+	// observe it. Generous bound so the test doesn't flake on a slow
+	// CI runner.
+	var grandchildPID int
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(pidFile)
+		if err == nil && len(b) > 0 {
+			s := strings.TrimSpace(string(b))
+			if pid, perr := strconv.Atoi(s); perr == nil && pid > 0 {
+				grandchildPID = pid
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NotZero(t, grandchildPID, "grandchild never recorded its PID")
+
+	// Confirm grandchild is alive right now.
+	require.True(t, procExists(grandchildPID), "grandchild not visible in /proc before cancel")
+
+	// Now — and only now, with grandchild confirmed alive — cancel
+	// and assert it dies within 2s. This is the regression guard:
+	// unmodified code (CommandContext + leader-only Kill) leaves the
+	// grandchild alive for the natural sleep duration (30s here).
+	start := time.Now()
+	cancel()
+
+	gone := false
+	for time.Since(start) < 2*time.Second {
+		if !procExists(grandchildPID) {
+			gone = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.True(t, gone, "grandchild PID %d still alive 2s after cancel — process tree leak", grandchildPID)
+
+	// Run() must also return promptly (covered by elapsed in the
+	// caller goroutine). 3s gives the implementation slack for
+	// WaitDelay-driven pipe close.
+	select {
+	case err := <-done:
+		require.Error(t, err, "Run() must return ctx error after cancel")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run() did not return within 3s of cancel")
+	}
+}
+
+// procExists returns true if /proc/<pid> is currently a directory. On
+// Linux this is the canonical liveness check that doesn't require
+// signaling permissions.
+func procExists(pid int) bool {
+	_, err := os.Stat("/proc/" + strconv.Itoa(pid))
+	return err == nil
+}

--- a/migrationAssistantTUI/internal/feature/deploy/real_pgroup_other.go
+++ b/migrationAssistantTUI/internal/feature/deploy/real_pgroup_other.go
@@ -1,0 +1,21 @@
+//go:build !unix
+
+package deploy
+
+import "os/exec"
+
+// configureProcessGroup is a no-op on non-Unix platforms. The TUI does
+// not officially support Windows (real_exec_test.go skips on windows),
+// but we keep these stubs so the package builds on all GOOS for
+// developer-tooling purposes (gopls, IDE indexing, cross-builds).
+func configureProcessGroup(_ *exec.Cmd) {}
+
+// killProcessGroup falls back to killing only the leader. On Windows
+// the equivalent would be a Job Object; we'd add it if/when we ship
+// there. The TUI does not target Windows.
+func killProcessGroup(c *exec.Cmd) error {
+	if c.Process == nil {
+		return nil
+	}
+	return c.Process.Kill()
+}

--- a/migrationAssistantTUI/internal/feature/deploy/real_pgroup_unix.go
+++ b/migrationAssistantTUI/internal/feature/deploy/real_pgroup_unix.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package deploy
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessGroup makes c the leader of a new process group.
+// Combined with killProcessGroup below, this lets us SIGKILL every
+// descendant (including backgrounded grandchildren that inherited
+// stdout/stderr pipes) on ctx cancel, breaking the liveness chain
+// that would otherwise block cmd.Wait until natural process exit.
+//
+// See the regression guard in real_exec_pgroup_test.go and the
+// CI failure documented at
+// https://github.com/opensearch-project/opensearch-migrations/pull/3008
+// (TestExecCommandRunner_Run_ContextCancelKillsProcess elapsed=5.002s
+// against unmodified CommandContext on ubuntu-22.04 / dash).
+func configureProcessGroup(c *exec.Cmd) {
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	c.SysProcAttr.Setpgid = true
+}
+
+// killProcessGroup sends SIGKILL to the entire process group rooted at
+// c.Process.Pid. The negative-pid form (kill(-pgid, sig)) is the POSIX
+// idiom for "every process in this group". Returns nil if the process
+// hasn't started yet (defensive — Cancel can theoretically race Start).
+func killProcessGroup(c *exec.Cmd) error {
+	if c.Process == nil {
+		return nil
+	}
+	// We set Setpgid above so the child's pgid == its pid; -pid
+	// targets that group. If something raced and the group is gone,
+	// Kill returns ESRCH which we treat as success (Cancel contract:
+	// nil or os.ErrProcessDone-equivalent is fine).
+	if err := syscall.Kill(-c.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
# Fix: kill ExecCommandRunner subprocess tree on ctx cancel

Stacked on #3008. Fixes the CI failure on `TestExecCommandRunner_Run_ContextCancelKillsProcess` (5.002s elapsed vs 2s budget) reported on the greenfield branch.

## What

`ExecCommandRunner.Run` now puts each subprocess in its own process group (`Setpgid: true`), overrides `c.Cancel` to send `SIGKILL` to `-pgid` (the whole group), and sets a `c.WaitDelay` backstop so `cmd.Wait` can never block forever on inherited FDs.

## Why

The CI runner uses ubuntu-22.04 where `/bin/sh` is dash. dash forks for `sh -c "sleep N"` rather than exec-replacing (bash 5.2 on the dev host does the latter, which is why this didn't reproduce locally at first). When `exec.CommandContext`'s default `Cancel` fires, it only `Kill()`s the leader. The orphaned grandchild keeps the inherited stdout pipe open and `cmd.Wait` blocks until it exits naturally — full sleep duration.

This is a textbook scenario; the fix is the textbook fix. Documented at length in commentary on `real_pgroup_unix.go::configureProcessGroup`.

## Files

- `migrationAssistantTUI/internal/feature/deploy/real.go` — switch to `c.Cancel = killProcessGroup; c.WaitDelay = 2s`
- `migrationAssistantTUI/internal/feature/deploy/real_pgroup_unix.go` — `Setpgid` + `kill(-pgid, SIGKILL)`
- `migrationAssistantTUI/internal/feature/deploy/real_pgroup_other.go` — Windows stub (TUI doesn't target Windows but cross-build still works)
- `migrationAssistantTUI/internal/feature/deploy/real_exec_pgroup_test.go` — regression guard

## Regression guard

The new test `TestExecCommandRunner_Run_KillsBackgroundedGrandchild` spawns a backgrounded `sh -c` grandchild that records its own pid to a temp file, waits for that pid to be observable in `/proc`, then cancels and asserts the grandchild is gone within 2s.

**Proven RED on baseline** by temporarily reverting `killProcessGroup` to leader-only `c.Process.Kill()` — test failed with `grandchild PID 3288030 still alive 2s after cancel — process tree leak`. With the fix, the test passes in 40ms wall.

## Verification

```
go test -race -count=2 ./...   # 30/30 packages green
go vet ./...                   # clean
gofmt -l .                     # clean
GOOS=windows go build ./...    # cross-builds clean
```

The original failing CI test (`TestExecCommandRunner_Run_ContextCancelKillsProcess`) also passes — the fix addresses both the local-baseline test and the dash-specific CI case via the same mechanism.

## Discovery note

First attempt used `exec.Command` + a manual ctx-watcher goroutine. Go rejects this at `Start` time:

```
exec: command with a non-nil Cancel was not created with CommandContext
```

The Go API requires `CommandContext` for any custom `Cancel`. We use it and override `Cancel`/`WaitDelay` before `Start`.
