### PR TITLE
[DRAFT/discussion] S3 tuple sink: self-scheduled age flush on its own worker thread (lock-free alternative)

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -707,10 +706,6 @@ public class TrafficReplayer {
             );
             ActiveContextMonitor finalActiveContextMonitor = activeContextMonitor;
             var finalBlockingTrafficSource = blockingTrafficSource;
-            // Holder so the scheduler tick can drive the tuple writer's age-based flush. The
-            // writer is created a few lines below (after the shutdown hook), so it's wired in
-            // via this reference once available.
-            var tupleWriterRef = new AtomicReference<ThreadLocalTupleWriter>();
             scheduledExecutorService.scheduleAtFixedRate(() -> {
                 activeContextLogger.atInfo().setMessage("Total requests outstanding at {}: {}")
                     .addArgument(Instant::now)
@@ -727,15 +722,6 @@ public class TrafficReplayer {
                 if (engine != null) {
                     engine.logHeartbeat();
                 }
-                // Drive the age-based S3 tuple flush. accept() only re-checks file age when a
-                // new tuple arrives, so without this a sink that goes quiet never rotates its
-                // last batch — leaving those tuple futures pending and the Kafka offset pinned
-                // (commit is gated on durable tuple output). Guarded inside the sink for the
-                // cross-thread access; never raises (errors are swallowed in periodicFlush).
-                var tupleWriterForFlush = tupleWriterRef.get();
-                if (tupleWriterForFlush != null) {
-                    tupleWriterForFlush.periodicFlush();
-                }
             }, ACTIVE_WORK_MONITOR_CADENCE_MS, ACTIVE_WORK_MONITOR_CADENCE_MS, TimeUnit.MILLISECONDS);
 
             setupShutdownHookForReplayer(tr);
@@ -743,7 +729,6 @@ public class TrafficReplayer {
                 params,
                 () -> transformationLoader.getTransformerFactoryLoader(tupleTransformerConfig)
             );
-            tupleWriterRef.set(tupleWriter);
             if (tupleWriter != null) {
                 tr.setupRunAndWaitForReplayWithShutdownChecks(
                     Duration.ofSeconds(params.observedPacketConnectionTimeout),

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/sink/ThreadLocalTupleWriter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/sink/ThreadLocalTupleWriter.java
@@ -81,25 +81,6 @@ public class ThreadLocalTupleWriter implements AutoCloseable {
         return future;
     }
 
-    /**
-     * Age-based flush across every registered sink. Driven from the replayer's shared
-     * scheduler thread (NOT a sink's owning event loop), so each sink's periodicFlush()
-     * must guard the buffer state it shares with accept(). Without this, a sink that
-     * stops receiving tuples never re-evaluates its max-age rotation, leaving the last
-     * batch's futures pending forever — which keeps the replayer's Kafka offset pinned
-     * (commit is gated on durable tuple output). Per-sink errors are swallowed so one
-     * bad sink can't stop the others (or the scheduler).
-     */
-    public void periodicFlush() {
-        sinks.forEach(sink -> {
-            try {
-                sink.periodicFlush();
-            } catch (Exception e) {
-                log.atError().setCause(e).setMessage("Error during periodic TupleSink flush").log();
-            }
-        });
-    }
-
     @Override
     public void close() {
         sinks.forEach(sink -> {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/TupleWriteBlockingBehaviorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/TupleWriteBlockingBehaviorTest.java
@@ -77,9 +77,6 @@ public class TupleWriteBlockingBehaviorTest extends InstrumentationTest {
         }
 
         @Override
-        public void periodicFlush() {}
-
-        @Override
         public void close() {
             releaseAll();
         }
@@ -107,9 +104,6 @@ public class TupleWriteBlockingBehaviorTest extends InstrumentationTest {
 
         @Override
         public void flush() {}
-
-        @Override
-        public void periodicFlush() {}
 
         @Override
         public void close() {}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/sink/GzipJsonLinesSinkTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/sink/GzipJsonLinesSinkTest.java
@@ -127,14 +127,14 @@ class GzipJsonLinesSinkTest {
     }
 
     @Test
-    void periodicFlushFlushesUncommittedTuples() throws Exception {
+    void flushFlushesUncommittedTuples() throws Exception {
         try (var sink = new GzipJsonLinesSink(tempDir, 10 * 1024 * 1024, Duration.ofMinutes(10))) {
             var f1 = new CompletableFuture<Void>();
             sink.accept(makeTuple("conn1.0"), f1);
             assertFalse(f1.isDone());
 
-            sink.periodicFlush();
-            assertTrue(f1.isDone(), "Future should complete on periodicFlush when tuples are pending");
+            sink.flush();
+            assertTrue(f1.isDone(), "Future should complete on flush when tuples are pending");
             f1.get(1, TimeUnit.SECONDS);
         }
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/sink/ThreadLocalTupleWriterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/sink/ThreadLocalTupleWriterTest.java
@@ -1,9 +1,7 @@
 package org.opensearch.migrations.replay.sink;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.opensearch.migrations.replay.ParsedHttpMessagesAsDicts;
@@ -13,8 +11,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ThreadLocalTupleWriterTest {
@@ -42,31 +38,5 @@ class ThreadLocalTupleWriterTest {
 
         Assertions.assertNotNull(writtenTuple.get());
         Assertions.assertEquals(true, writtenTuple.get().get("transformApplied"));
-    }
-
-    @Test
-    void periodicFlushFansOutToEveryRegisteredSink() {
-        // One sink is created per calling thread on first writeTuple(); capture each so we
-        // can verify periodicFlush() reaches all of them. This is the wiring that lets the
-        // replayer's scheduler drive age-based S3 rotation when traffic goes quiet.
-        List<TupleSink> createdSinks = new CopyOnWriteArrayList<>();
-        var parsed = mock(ParsedHttpMessagesAsDicts.class);
-        var tuple = mock(SourceTargetCaptureTuple.class);
-        var tupleMap = new LinkedHashMap<String, Object>();
-        tupleMap.put("connectionId", "stream.0");
-        when(parsed.toTupleMap(tuple)).thenReturn(tupleMap);
-
-        try (var writer = new ThreadLocalTupleWriter(sinkIndex -> {
-            var sink = spy(new CallbackTupleSink(m -> { }));
-            createdSinks.add(sink);
-            return sink;
-        })) {
-            writer.writeTuple(tuple, parsed).join();
-            Assertions.assertEquals(1, createdSinks.size(), "expected one sink for this thread");
-
-            writer.periodicFlush();
-
-            verify(createdSinks.get(0)).periodicFlush();
-        }
     }
 }

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/CallbackTupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/CallbackTupleSink.java
@@ -31,11 +31,6 @@ public class CallbackTupleSink implements TupleSink {
     }
 
     @Override
-    public void periodicFlush() {
-        // No time-based thresholds — futures are completed immediately in accept()
-    }
-
-    @Override
     public void close() {
         // No resources to release
     }

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/GzipJsonLinesSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/GzipJsonLinesSink.java
@@ -92,13 +92,6 @@ public class GzipJsonLinesSink implements TupleSink {
     }
 
     @Override
-    public void periodicFlush() {
-        if (!pendingFutures.isEmpty()) {
-            rotate();
-        }
-    }
-
-    @Override
     public void close() {
         if (gzipOut == null) {
             return;

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
@@ -175,16 +175,9 @@ public class S3TupleSink implements TupleSink {
         }, null);
     }
 
-    @Override
-    public void periodicFlush() {
-        // Retained for the TupleSink contract / external callers, but the sink now drives its
-        // own age flush from the worker thread (see periodicFlushOnWorker). Marshal so external
-        // callers remain safe.
-        runOnWorker(this::periodicFlushOnWorker, null);
-    }
-
-    /** Age-driven safety flush; runs on the worker thread. Only rotates buffered tuples once the
-     * file has reached its max age (size/count rotation is handled inline in accept()). */
+    /** Age-driven safety flush; runs on the worker thread (self-scheduled in the constructor).
+     * Only rotates buffered tuples once the file has reached its max age (size/count rotation is
+     * handled inline in accept()). */
     private void periodicFlushOnWorker() {
         if (!pendingFutures.isEmpty() && hasReachedMaxAge()) {
             rotate(true);

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -61,7 +62,13 @@ public class S3TupleSink implements TupleSink {
     private final Duration rotateAfterAge;
     private final int rotateAfterTuples;
     private final Duration uploadRetryDelay;
-    private final ScheduledExecutorService retryExecutor;
+    // Single work thread that owns ALL buffer state (gzipOut / pendingFutures / currentFile /
+    // counters). accept()/flush()/close() marshal onto it, and it self-schedules the age-based
+    // flush. Because every buffer mutation runs on this one thread, no lock is needed — this is
+    // the sink's own "event loop". (The async S3 upload callback runs on an SDK thread but only
+    // touches atomics, never buffer state.) This also frees the Netty event loop from the
+    // gzip/serialize work that accept() used to do inline.
+    private final ScheduledExecutorService executor;
     private final AtomicInteger activeUploads = new AtomicInteger();
     private final AtomicBoolean closeRequested = new AtomicBoolean();
     private final AtomicLong sequenceCounter = new AtomicLong();
@@ -118,24 +125,32 @@ public class S3TupleSink implements TupleSink {
         this.rotateAfterAge = rotateAfterAge;
         this.rotateAfterTuples = rotateAfterTuples;
         this.uploadRetryDelay = uploadRetryDelay;
-        this.retryExecutor = Executors.newSingleThreadScheduledExecutor(makeRetryThreadFactory());
+        this.executor = Executors.newSingleThreadScheduledExecutor(makeWorkerThreadFactory());
         openNewStream();
+        // Self-scheduled age flush: re-checks file age on its own thread so a sink that stops
+        // receiving tuples still rotates its trailing batch (otherwise those tuple futures never
+        // complete and the replayer's Kafka offset never advances). Cadence is a fraction of the
+        // max age so the worst-case extra latency past max-age is bounded. Min 1s floor avoids a
+        // busy schedule for tiny test ages.
+        var flushPeriodMs = Math.max(1000L, rotateAfterAge.toMillis() / 2);
+        executor.scheduleAtFixedRate(
+            this::periodicFlushOnWorker, flushPeriodMs, flushPeriodMs, TimeUnit.MILLISECONDS);
     }
-
-    // accept() runs on the owning Netty event loop, but periodicFlush() is now driven from
-    // the replayer's shared scheduler thread (so the age-based rotation fires when traffic
-    // goes quiet — otherwise the trailing buffer's tuple futures never complete and the
-    // replayer's Kafka offset never advances). That cross-thread flush means the methods
-    // mutating the buffer (gzipOut / pendingFutures / currentFile) can no longer assume
-    // single-threaded access, so they synchronize on this lock. The lock is only ever held
-    // for local buffer bookkeeping + kicking off the async upload — never across the S3 call.
-    private final Object bufferLock = new Object();
 
     @Override
     public void accept(Map<String, Object> tupleMap, CompletableFuture<Void> future) {
-        synchronized (bufferLock) {
+        // Serialize the tuple on the calling (event-loop) thread so a serialization failure can
+        // be reported synchronously and the tupleMap isn't retained across threads. The actual
+        // buffer write is marshalled onto the worker thread.
+        final byte[] json;
+        try {
+            json = mapper.writeValueAsBytes(tupleMap);
+        } catch (IOException e) {
+            future.completeExceptionally(e);
+            return;
+        }
+        runOnWorker(() -> {
             try {
-                byte[] json = mapper.writeValueAsBytes(tupleMap);
                 gzipOut.write(json);
                 gzipOut.write('\n');
                 uncompressedBytes += json.length + 1;
@@ -148,48 +163,79 @@ public class S3TupleSink implements TupleSink {
             if (shouldRotate()) {
                 rotate(true);
             }
-        }
+        }, future);
     }
 
     @Override
     public void flush() {
-        synchronized (bufferLock) {
-            if (pendingFutures.isEmpty()) {
-                return;
+        runOnWorker(() -> {
+            if (!pendingFutures.isEmpty()) {
+                rotate(true);
             }
-            rotate(true);
-        }
+        }, null);
     }
 
     @Override
     public void periodicFlush() {
-        synchronized (bufferLock) {
-            // Age-driven safety flush: only rotate if there are buffered tuples AND the file
-            // has reached its max age. Without the age gate this would upload a tiny object on
-            // every scheduler tick under steady traffic; shouldRotate() already covers size/count.
-            if (!pendingFutures.isEmpty() && hasReachedMaxAge()) {
-                rotate(true);
-            }
+        // Retained for the TupleSink contract / external callers, but the sink now drives its
+        // own age flush from the worker thread (see periodicFlushOnWorker). Marshal so external
+        // callers remain safe.
+        runOnWorker(this::periodicFlushOnWorker, null);
+    }
+
+    /** Age-driven safety flush; runs on the worker thread. Only rotates buffered tuples once the
+     * file has reached its max age (size/count rotation is handled inline in accept()). */
+    private void periodicFlushOnWorker() {
+        if (!pendingFutures.isEmpty() && hasReachedMaxAge()) {
+            rotate(true);
         }
     }
 
     @Override
     public void close() {
         closeRequested.set(true);
-        synchronized (bufferLock) {
-            if (gzipOut == null) {
-                shutdownRetryExecutorIfDone();
-                return;
-            }
-            if (!pendingFutures.isEmpty()) {
-                rotate(false);
-            } else {
-                closeCurrentStream();
-                deleteFile(currentFile);
-                clearCurrentStream();
+        // Drain on the worker thread and block until it's done, so resources are released and
+        // pending tuples are flushed (their futures complete via the async upload) before return.
+        try {
+            runAndAwaitOnWorker(() -> {
+                if (gzipOut == null) {
+                    return;
+                }
+                if (!pendingFutures.isEmpty()) {
+                    rotate(false);
+                } else {
+                    closeCurrentStream();
+                    deleteFile(currentFile);
+                    clearCurrentStream();
+                }
+            });
+        } finally {
+            shutdownExecutorIfDone();
+        }
+    }
+
+    /** Submit buffer work to the single worker thread; on rejection (post-close) fail the
+     * associated future if any, so callers never wait forever. */
+    private void runOnWorker(Runnable task, CompletableFuture<Void> futureToFailOnReject) {
+        try {
+            executor.execute(task);
+        } catch (RejectedExecutionException e) {
+            if (futureToFailOnReject != null) {
+                futureToFailOnReject.completeExceptionally(e);
             }
         }
-        shutdownRetryExecutorIfDone();
+    }
+
+    private void runAndAwaitOnWorker(Runnable task) {
+        try {
+            executor.submit(task).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (RejectedExecutionException e) {
+            // already shutting down — nothing to drain
+        } catch (java.util.concurrent.ExecutionException e) {
+            log.atError().setCause(e.getCause()).setMessage("Error draining S3 tuple sink on close").log();
+        }
     }
 
     private boolean shouldRotate() {
@@ -288,7 +334,7 @@ public class S3TupleSink implements TupleSink {
                 deleteFile(file);
                 futures.forEach(f -> f.complete(null));
                 activeUploads.decrementAndGet();
-                shutdownRetryExecutorIfDone();
+                shutdownExecutorIfDone();
                 return;
             }
 
@@ -299,7 +345,7 @@ public class S3TupleSink implements TupleSink {
                 .addArgument(attempt)
                 .addArgument(uploadRetryDelay::toMillis)
                 .log();
-            retryExecutor.schedule(
+            executor.schedule(
                 () -> uploadFileWithRetries(key, file, futures, attempt + 1),
                 uploadRetryDelay.toMillis(),
                 TimeUnit.MILLISECONDS
@@ -317,17 +363,17 @@ public class S3TupleSink implements TupleSink {
             .thenApply(r -> null);
     }
 
-    private ThreadFactory makeRetryThreadFactory() {
+    private ThreadFactory makeWorkerThreadFactory() {
         return runnable -> {
-            var thread = new Thread(runnable, "s3-tuple-sink-retry-" + sinkIndex);
+            var thread = new Thread(runnable, "s3-tuple-sink-worker-" + sinkIndex);
             thread.setDaemon(false);
             return thread;
         };
     }
 
-    private void shutdownRetryExecutorIfDone() {
+    private void shutdownExecutorIfDone() {
         if (closeRequested.get() && activeUploads.get() == 0) {
-            retryExecutor.shutdown();
+            executor.shutdown();
         }
     }
 

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/TupleSink.java
@@ -17,9 +17,6 @@ public interface TupleSink extends AutoCloseable {
     /** Flush any buffered data. Called when no more items are immediately available. */
     void flush();
 
-    /** Periodic callback even when no events arrive. Implementations should check time-based thresholds. */
-    void periodicFlush();
-
     /** Finalize: flush, commit, complete all outstanding futures, release resources. */
     @Override
     void close();

--- a/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
+++ b/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
@@ -64,7 +64,7 @@ class S3TupleSinkTest {
     }
 
     @Test
-    void periodicFlushUploadsPendingTupleOnceMaxAgeReached() throws Exception {
+    void selfScheduledFlushUploadsPendingTupleOnceMaxAgeReached() throws Exception {
         var s3Client = mock(S3AsyncClient.class);
         var upload = new CompletableFuture<PutObjectResponse>();
         var putCallCount = new AtomicInteger();
@@ -75,20 +75,13 @@ class S3TupleSinkTest {
                 return upload;
             });
 
-        // Short max-age so the age-gated periodic flush fires on the second tick.
+        // Short max-age: the sink's own scheduled worker should rotate the trailing batch
+        // WITHOUT any further accept() calls or external flush — this is the stall fix.
         try (var sink = makeSink(s3Client, 100, Duration.ofMillis(50))) {
             var future = new CompletableFuture<Void>();
             sink.accept(makeTuple("conn1.0"), future);
-            assertFalse(future.isDone(), "Tuple future should wait until the batch is uploaded");
 
-            // Drive the age-based flush until the file reaches its max age and rotates.
-            var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-            while (putCallCount.get() == 0 && System.nanoTime() < deadline) {
-                sink.periodicFlush();
-                Thread.sleep(20);
-            }
-            assertEquals(1, putCallCount.get(),
-                "Periodic flush should upload the pending tuple batch once max age is reached");
+            waitForPutCalls(putCallCount, 1);
             assertFalse(future.isDone(), "Tuple future should still wait for the upload result");
 
             upload.complete(PutObjectResponse.builder().build());
@@ -97,16 +90,16 @@ class S3TupleSinkTest {
     }
 
     @Test
-    void periodicFlushDoesNotUploadBeforeMaxAge() {
+    void doesNotUploadBeforeMaxAgeWhileQuiet() throws Exception {
         var s3Client = mock(S3AsyncClient.class);
 
-        // Long max-age: a quiet sink should NOT upload tiny objects on every scheduler tick.
+        // Long max-age: a quiet sink must NOT upload a tiny object on its scheduled ticks.
         try (var sink = makeSink(s3Client, 100, Duration.ofMinutes(10))) {
             var future = new CompletableFuture<Void>();
             sink.accept(makeTuple("conn1.0"), future);
 
-            sink.periodicFlush();
-            sink.periodicFlush();
+            // Give the scheduled worker several opportunities to (incorrectly) flush.
+            Thread.sleep(200);
 
             verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class));
             assertFalse(future.isDone(), "Tuple future stays pending until size/count/age rotation");


### PR DESCRIPTION
**Draft for viewing/discussion only — not for merge.**

Alternative implementation of the CDC drain-stall fix that's on the base branch as commit `4042d6c0` (which drives `periodicFlush` from the shared monitor scheduler and guards `S3TupleSink` with a `bufferLock`).

This branch instead makes `S3TupleSink` **self-managing and lock-free**: it promotes its existing single-thread scheduled executor to be the sink's own work loop, marshals all buffer ops onto it, and self-schedules the age-based flush. This restores the original "one thread owns the buffer, no synchronization" invariant rather than adding a lock around cross-thread access.

### Diff intent
Base = `feat/kafka-describe-consumer-group-time-lag`, so this PR's diff is exactly the **before/after** of the two approaches:
- **removes** `ThreadLocalTupleWriter.periodicFlush()` + the `TrafficReplayer` monitor-loop hook (external drive)
- **rewrites** `S3TupleSink` to a self-scheduled single-thread loop (removes `bufferLock`)

### Why this shape
- `accept()`/`flush()`/`close()` marshal buffer work onto the sink's single worker thread; the age flush is `scheduleAtFixedRate`'d on that same thread. No lock — every buffer mutation is single-threaded by construction.
- `accept()` still serializes to bytes synchronously on the caller (so serialization failures report synchronously and the tuple map isn't retained cross-thread); also moves gzip/serialize off the Netty send thread.
- `close()` drains on the worker and blocks until done so resources/futures settle before return.
- Async S3 upload callback only touches atomics, never buffer state.

### Trade-offs to discuss
1. **`accept()` becomes async** (buffer write hops to the worker). The write future was already async so the caller contract is unchanged, but it's a behavior change worth a look.
2. **One worker thread per sink** (i.e. per Netty event loop). The sink already had a retry-executor thread; this unifies onto it rather than adding threads. Per-sink (vs one writer-wide loop) preserves the existing parallel-upload sharding.
3. vs the lock approach: the lock was correctness-neutral and ~uncontended (per-sink, rare scheduler visitor). This is "more idiomatic / honors the original invariant" at the cost of the marshalling indirection. Either is viable — opening this so we can pick.

Tests updated: self-scheduled flush uploads the trailing batch once max age is reached with no further `accept()`/external flush; quiet sink doesn't upload before max age; close drains; same-key retry holds.

DCO: signed off.