### PR TITLE
perf(tupleSink): serialize on worker thread + bounded blocking backpressure

### DIFF
--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/limiter/ProducerLimiter.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/limiter/ProducerLimiter.java
@@ -1,0 +1,54 @@
+package org.opensearch.migrations.replay.limiter;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Producer-side backpressure: a producer blocks until there is capacity for the work it is about to
+ * enqueue, then holds a {@link Reservation} for the lifetime of that work and releases it when the
+ * work is durably done. Used to bound a resource that accumulates faster than it drains (e.g.
+ * accepted-but-not-yet-uploaded tuples, or rotated-but-not-yet-uploaded files) so the producer slows
+ * down under pressure instead of failing or growing without bound.
+ *
+ * <p>Weight is whatever the gate measures — a count of items, or a number of bytes. An oversized
+ * request is clamped to the limiter's capacity so a single large item can still proceed solo rather
+ * than block forever.</p>
+ */
+public interface ProducerLimiter {
+
+    /** A held reservation. {@link #release()} returns the reserved weight to the limiter and is idempotent. */
+    interface Reservation {
+        void release();
+    }
+
+    /**
+     * Block until {@code weight} fits within the limiter (clamped to capacity), then return a held
+     * {@link Reservation}. Returns {@link Optional#empty()} iff the thread was interrupted while
+     * waiting (interrupt flag re-set); callers typically treat that as shutdown.
+     */
+    Optional<Reservation> reserve(long weight);
+
+    /**
+     * Convenience for the common single-limiter case: {@link #reserve} and, on success, auto-release
+     * exactly once when {@code future} settles (normally or exceptionally).
+     *
+     * <p>Callers that must hold reservations across <i>multiple</i> limiters should use
+     * {@link #reserve} directly and register a single combined release, so a reservation already
+     * taken is freed if a later reservation is interrupted.</p>
+     *
+     * @return {@code true} if reserved (release wired to {@code future}); {@code false} iff interrupted.
+     */
+    default boolean reserveUntilSettled(long weight, CompletableFuture<?> future) {
+        var reservation = reserve(weight);
+        if (reservation.isEmpty()) {
+            return false;
+        }
+        future.whenComplete((v, t) -> reservation.get().release());
+        return true;
+    }
+
+    /** Currently-available capacity in the underlying gate's permit unit (for logging; racy). */
+    int availablePermits();
+
+    String name();
+}

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/limiter/WeightedBlockingGate.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/limiter/WeightedBlockingGate.java
@@ -1,0 +1,109 @@
+package org.opensearch.migrations.replay.limiter;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * A weighted, blocking capacity gate over a single {@link Semaphore} — one gate bounds one
+ * dimension (e.g. a count of items, or a number of bytes).
+ *
+ * <p>The gate's job is the small bundle of logic that backpressure callers otherwise hand-roll
+ * around a raw semaphore:</p>
+ * <ul>
+ *   <li><b>Weight → permits.</b> A caller thinks in raw weights (1 item, N bytes); the gate
+ *       converts to permits. Byte gates are denominated in KiB ({@link #ofBytes}) so a multi-GiB
+ *       capacity still fits the int permit count a {@link Semaphore} uses.</li>
+ *   <li><b>Clamp to capacity.</b> {@link #permitsFor} clamps an oversized request down to the full
+ *       capacity, so a single item larger than the whole gate can still proceed solo rather than
+ *       block forever against a permit count it could never satisfy.</li>
+ *   <li><b>Balanced release by construction.</b> A caller computes {@code int p = permitsFor(w)}
+ *       once and passes the same {@code p} to {@link #acquire(int)} and {@link #release(int)}, so
+ *       the amount released always matches the amount acquired.</li>
+ * </ul>
+ *
+ * <p>The gate is intentionally unaware of {@link java.util.concurrent.CompletableFuture} or any
+ * release lifecycle — callers (or a {@link ProducerLimiter}) decide when to release. It is safe for
+ * concurrent use; the underlying semaphore is non-fair.</p>
+ */
+public final class WeightedBlockingGate {
+
+    /** KiB granularity for byte-denominated gates, so a large byte capacity stays within int permits. */
+    private static final long BYTE_PERMIT_UNIT = 1024L;
+
+    private final String name;
+    private final int capacityPermits;
+    private final long unitBytes;
+    private final Semaphore semaphore;
+
+    private WeightedBlockingGate(String name, int capacityPermits, long unitBytes) {
+        this.name = name;
+        this.capacityPermits = capacityPermits;
+        this.unitBytes = unitBytes;
+        this.semaphore = new Semaphore(capacityPermits);
+    }
+
+    /** A gate whose weight is a raw count (1 permit per unit of weight). */
+    public static WeightedBlockingGate ofCount(String name, int capacity) {
+        return new WeightedBlockingGate(name, Math.max(0, capacity), 1L);
+    }
+
+    /** A gate whose weight is a byte count; capacity and requests are denominated in KiB permits. */
+    public static WeightedBlockingGate ofBytes(String name, long capacityBytes) {
+        return new WeightedBlockingGate(name, toPermits(capacityBytes, BYTE_PERMIT_UNIT), BYTE_PERMIT_UNIT);
+    }
+
+    /**
+     * Convert a raw weight (count or bytes) into this gate's permit unit (ceil), clamped to
+     * {@code [0, capacity]}. Clamping to capacity is what lets an oversized item proceed solo.
+     */
+    public int permitsFor(long rawWeight) {
+        return Math.min(capacityPermits, toPermits(rawWeight, unitBytes));
+    }
+
+    /**
+     * Block until {@code permits} are available and acquire them. {@code permits} is expected to be
+     * an already-clamped value from {@link #permitsFor}. A non-positive count is a no-op.
+     *
+     * @return {@code true} once acquired; {@code false} iff the thread was interrupted while waiting
+     *         (the interrupt flag is re-set). Never returns {@code false} merely because the gate is
+     *         full — that just waits.
+     */
+    public boolean acquire(int permits) {
+        if (permits <= 0) {
+            return true;
+        }
+        try {
+            semaphore.acquire(permits);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    /** Release {@code permits} previously acquired from this gate. A non-positive count is a no-op. */
+    public void release(int permits) {
+        if (permits > 0) {
+            semaphore.release(permits);
+        }
+    }
+
+    /** Currently-available permits (for logging/heartbeats; inherently racy). */
+    public int availablePermits() {
+        return semaphore.availablePermits();
+    }
+
+    public int capacityPermits() {
+        return capacityPermits;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    private static int toPermits(long rawWeight, long unit) {
+        if (rawWeight <= 0) {
+            return 0;
+        }
+        return (int) Math.min(Integer.MAX_VALUE, (rawWeight + unit - 1) / unit);
+    }
+}

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/limiter/WeightedProducerLimiter.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/limiter/WeightedProducerLimiter.java
@@ -1,0 +1,52 @@
+package org.opensearch.migrations.replay.limiter;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A {@link ProducerLimiter} backed by a single {@link WeightedBlockingGate}. Each {@link #reserve}
+ * computes the clamped permit count once and hands back a {@link Reservation} that releases exactly
+ * that many permits, at most once (guarded by an {@link AtomicBoolean}).
+ */
+public final class WeightedProducerLimiter implements ProducerLimiter {
+
+    private final WeightedBlockingGate gate;
+
+    public WeightedProducerLimiter(WeightedBlockingGate gate) {
+        this.gate = gate;
+    }
+
+    /** A count-bounded producer limiter (1 permit per unit of weight). */
+    public static WeightedProducerLimiter ofCount(String name, int capacity) {
+        return new WeightedProducerLimiter(WeightedBlockingGate.ofCount(name, capacity));
+    }
+
+    /** A byte-bounded producer limiter (KiB-denominated permits). */
+    public static WeightedProducerLimiter ofBytes(String name, long capacityBytes) {
+        return new WeightedProducerLimiter(WeightedBlockingGate.ofBytes(name, capacityBytes));
+    }
+
+    @Override
+    public Optional<Reservation> reserve(long weight) {
+        int permits = gate.permitsFor(weight);
+        if (!gate.acquire(permits)) {
+            return Optional.empty();  // interrupted while waiting
+        }
+        var released = new AtomicBoolean(false);
+        return Optional.of(() -> {
+            if (released.compareAndSet(false, true)) {
+                gate.release(permits);
+            }
+        });
+    }
+
+    @Override
+    public int availablePermits() {
+        return gate.availablePermits();
+    }
+
+    @Override
+    public String name() {
+        return gate.name();
+    }
+}

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
@@ -53,24 +53,41 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  * pressure: a failed tuple write is fatal to the replayer and it shuts down WITHOUT committing the
  * held offsets (TrafficReplayerCore.failReplayForTupleWrite), so on restart it resumes at the same
  * offset, re-reads the same tuples, and — if S3 is still down — crash-loops forever, never
- * advancing. So instead we apply real backpressure: a semaphore caps accepted-but-not-yet-durably-
- * uploaded tuples at {@code maxInFlightTuples}, and when the cap is reached {@code accept()} BLOCKS
- * the calling thread until a permit frees (i.e. until an in-flight upload completes). This bounds
- * memory (buffered tuples + temp files + pending futures) while letting the replayer ride out an S3
- * outage and resume — throughput drops to zero during the outage by design, rather than failing.
- * The blocking happens on the replay response-completion thread, which is independent of the S3 SDK
- * threads and the sink's worker thread, so the upload/retry machinery keeps draining (no deadlock).
- * Permits are released when each tuple's future settles.</p>
+ * advancing. So instead we apply real backpressure via TWO gates, each guarding the resource that
+ * accumulates at its stage; both BLOCK (never fail) so the replayer rides out an S3 outage and
+ * resumes, with throughput dropping toward zero during the outage by design:</p>
+ * <ul>
+ *   <li><b>Intake gate (producer-side, coarse count).</b> {@code accept()} blocks until one of
+ *       {@code maxInFlightTuples} permits is free, bounding the heap held by accepted-but-not-yet-
+ *       durably-uploaded tuples (queued tupleMaps + pending futures). Count, not bytes, because with
+ *       serialization deferred to the worker (Option A) the byte size isn't known at accept() time;
+ *       the byte-accurate bound is the disk gate below. Released when each tuple future settles.
+ *       Blocks the replay response-completion thread — independent of the worker/SDK threads that
+ *       drain it, so no deadlock.</li>
+ *   <li><b>Disk-backlog gate (worker-side, bytes + file count).</b> Rotated-but-not-yet-uploaded
+ *       temp files are the genuinely unbounded resource under an outage (each rotation adds a file
+ *       to /tmp; none delete until upload succeeds). Before handing a finished file to the upload
+ *       retry loop, the worker thread blocks until {@code maxOutstandingUploadBytes} AND
+ *       {@code maxOutstandingUploadFiles} permits are free, then releases them on upload success.
+ *       Because this blocks the single worker thread, new writes and the age flush also pause while
+ *       the disk backlog is full — intended backpressure. Drains via the SDK's upload threads.</li>
+ * </ul>
  */
 @Slf4j
 public class S3TupleSink implements TupleSink {
     static final Duration DEFAULT_UPLOAD_RETRY_DELAY = Duration.ofSeconds(10);
 
     /**
-     * Default cap on accepted-but-not-yet-durably-uploaded tuples. Bounds memory under a sustained
-     * S3 outage; when reached, accept() blocks (waits for an upload to drain) rather than failing.
+     * Default intake-gate cap on accepted-but-not-yet-durably-uploaded tuples (coarse count bound on
+     * heap). When reached, accept() blocks (waits for an upload to drain) rather than failing.
      */
     static final int DEFAULT_MAX_IN_FLIGHT_TUPLES = 100_000;
+
+    /** Default disk-backlog cap on bytes of rotated-but-not-yet-uploaded temp files (1 GiB). */
+    static final long DEFAULT_MAX_OUTSTANDING_UPLOAD_BYTES = 1024L * 1024L * 1024L;
+
+    /** Default disk-backlog cap on the number of rotated-but-not-yet-uploaded temp files. */
+    static final int DEFAULT_MAX_OUTSTANDING_UPLOAD_FILES = 64;
 
     private static final DateTimeFormatter TIMESTAMP_FORMAT =
         DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
@@ -94,9 +111,21 @@ public class S3TupleSink implements TupleSink {
     // upload callback runs on an SDK thread but only touches atomics, never buffer state.) This
     // keeps the Netty event loop free of all per-tuple serialize/gzip/disk work.
     private final ScheduledExecutorService executor;
-    // Bounds accepted-but-not-yet-durably-uploaded tuples. See class javadoc (Backpressure).
+    // Separate scheduler for upload retries + the upload-success release path. MUST be distinct from
+    // `executor`: the worker thread can block in rotate() on the disk-backlog gate, and the permits
+    // it waits on are only released after an upload succeeds. If retries were rescheduled onto the
+    // (single, parked) worker they could never run → the gate would never drain → deadlock. Keeping
+    // retries on their own thread means the worker can park safely.
+    private final ScheduledExecutorService uploadRetryScheduler;
+    // Intake gate: bounds accepted-but-not-yet-durably-uploaded tuples (coarse count). See javadoc.
     private final Semaphore inFlightPermits;
     private final int maxInFlightTuples;
+    // Disk-backlog gates: bound rotated-but-not-yet-uploaded temp files by total size and count.
+    // Byte permits are denominated in KiB so the permit count stays an int even for large caps.
+    private static final long UPLOAD_BYTE_PERMIT_UNIT = 1024L;
+    private final Semaphore outstandingUploadBytePermits;
+    private final Semaphore outstandingUploadFilePermits;
+    private final int maxOutstandingUploadBytePermits;
     private final AtomicInteger activeUploads = new AtomicInteger();
     private final AtomicBoolean closeRequested = new AtomicBoolean();
     private final AtomicLong sequenceCounter = new AtomicLong();
@@ -161,6 +190,25 @@ public class S3TupleSink implements TupleSink {
         Duration uploadRetryDelay,
         int maxInFlightTuples
     ) {
+        this(s3Client, bucket, prefix, replayerId, sinkIndex, rotateAfterBytes, rotateAfterAge,
+            rotateAfterTuples, uploadRetryDelay, maxInFlightTuples,
+            DEFAULT_MAX_OUTSTANDING_UPLOAD_BYTES, DEFAULT_MAX_OUTSTANDING_UPLOAD_FILES);
+    }
+
+    S3TupleSink(
+        S3AsyncClient s3Client,
+        String bucket,
+        String prefix,
+        String replayerId,
+        int sinkIndex,
+        long rotateAfterBytes,
+        Duration rotateAfterAge,
+        int rotateAfterTuples,
+        Duration uploadRetryDelay,
+        int maxInFlightTuples,
+        long maxOutstandingUploadBytes,
+        int maxOutstandingUploadFiles
+    ) {
         this.s3Client = s3Client;
         this.bucket = bucket;
         this.prefix = prefix;
@@ -172,7 +220,14 @@ public class S3TupleSink implements TupleSink {
         this.uploadRetryDelay = uploadRetryDelay;
         this.maxInFlightTuples = maxInFlightTuples;
         this.inFlightPermits = new Semaphore(maxInFlightTuples);
-        this.executor = Executors.newSingleThreadScheduledExecutor(makeWorkerThreadFactory());
+        // Byte gate in KiB units (ceil) so a large cap stays within int permit range.
+        this.maxOutstandingUploadBytePermits =
+            (int) Math.min(Integer.MAX_VALUE, (maxOutstandingUploadBytes + UPLOAD_BYTE_PERMIT_UNIT - 1)
+                / UPLOAD_BYTE_PERMIT_UNIT);
+        this.outstandingUploadBytePermits = new Semaphore(maxOutstandingUploadBytePermits);
+        this.outstandingUploadFilePermits = new Semaphore(maxOutstandingUploadFiles);
+        this.executor = Executors.newSingleThreadScheduledExecutor(makeThreadFactory("worker"));
+        this.uploadRetryScheduler = Executors.newSingleThreadScheduledExecutor(makeThreadFactory("upload-retry"));
         openNewStream();
         // Self-scheduled age flush: re-checks file age on its own thread so a sink that stops
         // receiving tuples still rotates its trailing batch (otherwise those tuple futures never
@@ -331,15 +386,57 @@ public class S3TupleSink implements TupleSink {
             return;
         }
 
+        // Disk-backlog gate: block the worker until the rotated file fits within the outstanding-
+        // upload caps (bytes + file count). This is the byte-accurate bound that protects /tmp from
+        // a sustained S3 outage; the worker parking here also pauses new writes + the age flush
+        // (intended backpressure). Permits are released on upload success (see uploadFileWithRetries).
+        var bytePermits = acquireDiskBacklogPermits(file);
+
         log.atInfo().setMessage("Completing S3 upload to s3://{}/{}").addArgument(bucket).addArgument(key).log();
 
         activeUploads.incrementAndGet();
-        uploadFileWithRetries(key, file, futures, 1);
+        uploadFileWithRetries(key, file, futures, bytePermits, 1);
 
         if (openNextStream) {
             openNewStream();
         } else {
             clearCurrentStream();
+        }
+    }
+
+    /**
+     * Block (on the worker thread) until the just-finished file fits within the outstanding-upload
+     * byte + file caps, then return the number of byte permits reserved (to release on success). A
+     * file larger than the whole byte cap is clamped to the cap so it can still proceed solo rather
+     * than deadlock. Interruption (shutdown) returns the clamped count without having acquired, so
+     * release stays balanced.
+     */
+    private int acquireDiskBacklogPermits(Path file) {
+        long sizeBytes;
+        try {
+            sizeBytes = Files.size(file);
+        } catch (IOException e) {
+            // Can't size it — don't block on the byte gate for this file; still take a file permit.
+            sizeBytes = 0;
+        }
+        int bytePermits = (int) Math.min(
+            maxOutstandingUploadBytePermits,
+            (sizeBytes + UPLOAD_BYTE_PERMIT_UNIT - 1) / UPLOAD_BYTE_PERMIT_UNIT);
+        try {
+            outstandingUploadFilePermits.acquire();
+            if (bytePermits > 0) {
+                outstandingUploadBytePermits.acquire(bytePermits);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return bytePermits;
+    }
+
+    private void releaseDiskBacklogPermits(int bytePermits) {
+        outstandingUploadFilePermits.release();
+        if (bytePermits > 0) {
+            outstandingUploadBytePermits.release(bytePermits);
         }
     }
 
@@ -392,11 +489,15 @@ public class S3TupleSink implements TupleSink {
         String key,
         Path file,
         List<CompletableFuture<Void>> futures,
+        int diskBacklogBytePermits,
         int attempt
     ) {
         uploadFile(key, file).whenComplete((response, error) -> {
             if (error == null) {
                 deleteFile(file);
+                // Release the disk-backlog gate first: the file is gone and its futures are about
+                // to complete, so unblock the worker (which may be parked in rotate()) promptly.
+                releaseDiskBacklogPermits(diskBacklogBytePermits);
                 futures.forEach(f -> f.complete(null));
                 activeUploads.decrementAndGet();
                 shutdownExecutorIfDone();
@@ -410,8 +511,8 @@ public class S3TupleSink implements TupleSink {
                 .addArgument(attempt)
                 .addArgument(uploadRetryDelay::toMillis)
                 .log();
-            executor.schedule(
-                () -> uploadFileWithRetries(key, file, futures, attempt + 1),
+            uploadRetryScheduler.schedule(
+                () -> uploadFileWithRetries(key, file, futures, diskBacklogBytePermits, attempt + 1),
                 uploadRetryDelay.toMillis(),
                 TimeUnit.MILLISECONDS
             );
@@ -428,9 +529,9 @@ public class S3TupleSink implements TupleSink {
             .thenApply(r -> null);
     }
 
-    private ThreadFactory makeWorkerThreadFactory() {
+    private ThreadFactory makeThreadFactory(String role) {
         return runnable -> {
-            var thread = new Thread(runnable, "s3-tuple-sink-worker-" + sinkIndex);
+            var thread = new Thread(runnable, "s3-tuple-sink-" + role + "-" + sinkIndex);
             thread.setDaemon(false);
             return thread;
         };
@@ -439,6 +540,7 @@ public class S3TupleSink implements TupleSink {
     private void shutdownExecutorIfDone() {
         if (closeRequested.get() && activeUploads.get() == 0) {
             executor.shutdown();
+            uploadRetryScheduler.shutdown();
         }
     }
 

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
@@ -9,7 +9,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -57,13 +59,15 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  * accumulates at its stage; both BLOCK (never fail) so the replayer rides out an S3 outage and
  * resumes, with throughput dropping toward zero during the outage by design:</p>
  * <ul>
- *   <li><b>Intake gate (producer-side, coarse count).</b> {@code accept()} blocks until one of
- *       {@code maxInFlightTuples} permits is free, bounding the heap held by accepted-but-not-yet-
- *       durably-uploaded tuples (queued tupleMaps + pending futures). Count, not bytes, because with
- *       serialization deferred to the worker (Option A) the byte size isn't known at accept() time;
- *       the byte-accurate bound is the disk gate below. Released when each tuple future settles.
- *       Blocks the replay response-completion thread — independent of the worker/SDK threads that
- *       drain it, so no deadlock.</li>
+ *   <li><b>Intake gate (producer-side, count + coarse bytes).</b> {@code accept()} blocks until both
+ *       a tuple permit (cap {@code maxInFlightTuples}) and enough byte permits for the tuple's
+ *       estimated size (cap {@code maxInFlightTupleBytes}) are free, bounding the heap held by
+ *       accepted-but-not-yet-durably-uploaded tuples (queued tupleMaps + pending futures) by both
+ *       count and size — whichever fills first throttles. The byte figure is a coarse structural
+ *       estimate (sum of CharSequence lengths, computed on the calling thread without serializing),
+ *       which is why it's paired with the count cap; the byte-accurate bound is the disk gate below.
+ *       Both permit sets release when each tuple future settles. Blocks the replay response-completion
+ *       thread — independent of the worker/SDK threads that drain it, so no deadlock.</li>
  *   <li><b>Disk-backlog gate (worker-side, bytes + file count).</b> Rotated-but-not-yet-uploaded
  *       temp files are the genuinely unbounded resource under an outage (each rotation adds a file
  *       to /tmp; none delete until upload succeeds). Before handing a finished file to the upload
@@ -78,16 +82,33 @@ public class S3TupleSink implements TupleSink {
     static final Duration DEFAULT_UPLOAD_RETRY_DELAY = Duration.ofSeconds(10);
 
     /**
-     * Default intake-gate cap on accepted-but-not-yet-durably-uploaded tuples (coarse count bound on
-     * heap). When reached, accept() blocks (waits for an upload to drain) rather than failing.
+     * Default intake-gate cap on the number of accepted-but-not-yet-durably-uploaded tuples (coarse
+     * count bound on heap). When reached, accept() blocks (waits for an upload to drain) rather than
+     * failing.
      */
     static final int DEFAULT_MAX_IN_FLIGHT_TUPLES = 100_000;
+
+    /**
+     * Default intake-gate cap on the estimated bytes of accepted-but-not-yet-durably-uploaded tuples
+     * (256 MiB). Guards against a small number of very large tuples (big request/response payloads)
+     * blowing the heap before the count cap above would trip. Coarse by design — see
+     * {@link #estimateTupleBytes}.
+     */
+    static final long DEFAULT_MAX_IN_FLIGHT_TUPLE_BYTES = 256L * 1024L * 1024L;
 
     /** Default disk-backlog cap on bytes of rotated-but-not-yet-uploaded temp files (1 GiB). */
     static final long DEFAULT_MAX_OUTSTANDING_UPLOAD_BYTES = 1024L * 1024L * 1024L;
 
     /** Default disk-backlog cap on the number of rotated-but-not-yet-uploaded temp files. */
     static final int DEFAULT_MAX_OUTSTANDING_UPLOAD_FILES = 64;
+
+    /**
+     * Upper bound on nodes walked by {@link #estimateTupleBytes}. Caps the calling-thread cost of
+     * the estimate and makes it immune to deeply-nested / self-referential maps. A normal tuple has
+     * far fewer nodes than this; the bulk of its size is in a handful of long payload strings, each
+     * counted in O(1), so the budget only bites on pathological structures.
+     */
+    static final int ESTIMATE_NODE_BUDGET = 10_000;
 
     private static final DateTimeFormatter TIMESTAMP_FORMAT =
         DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
@@ -117,12 +138,16 @@ public class S3TupleSink implements TupleSink {
     // (single, parked) worker they could never run → the gate would never drain → deadlock. Keeping
     // retries on their own thread means the worker can park safely.
     private final ScheduledExecutorService uploadRetryScheduler;
-    // Intake gate: bounds accepted-but-not-yet-durably-uploaded tuples (coarse count). See javadoc.
-    private final Semaphore inFlightPermits;
+    // Byte-denominated semaphores count permits in KiB units (ceil) so the permit count stays an int
+    // even for multi-GiB caps. Shared by the intake byte gate and the disk-backlog byte gate.
+    private static final long BYTE_PERMIT_UNIT = 1024L;
+    // Intake gate: bounds accepted-but-not-yet-durably-uploaded tuples by count AND estimated bytes
+    // (either fills first). See class javadoc.
+    private final Semaphore inFlightTuplePermits;
+    private final Semaphore inFlightBytePermits;
     private final int maxInFlightTuples;
+    private final int maxInFlightBytePermits;
     // Disk-backlog gates: bound rotated-but-not-yet-uploaded temp files by total size and count.
-    // Byte permits are denominated in KiB so the permit count stays an int even for large caps.
-    private static final long UPLOAD_BYTE_PERMIT_UNIT = 1024L;
     private final Semaphore outstandingUploadBytePermits;
     private final Semaphore outstandingUploadFilePermits;
     private final int maxOutstandingUploadBytePermits;
@@ -191,7 +216,7 @@ public class S3TupleSink implements TupleSink {
         int maxInFlightTuples
     ) {
         this(s3Client, bucket, prefix, replayerId, sinkIndex, rotateAfterBytes, rotateAfterAge,
-            rotateAfterTuples, uploadRetryDelay, maxInFlightTuples,
+            rotateAfterTuples, uploadRetryDelay, maxInFlightTuples, DEFAULT_MAX_IN_FLIGHT_TUPLE_BYTES,
             DEFAULT_MAX_OUTSTANDING_UPLOAD_BYTES, DEFAULT_MAX_OUTSTANDING_UPLOAD_FILES);
     }
 
@@ -206,6 +231,7 @@ public class S3TupleSink implements TupleSink {
         int rotateAfterTuples,
         Duration uploadRetryDelay,
         int maxInFlightTuples,
+        long maxInFlightTupleBytes,
         long maxOutstandingUploadBytes,
         int maxOutstandingUploadFiles
     ) {
@@ -219,11 +245,10 @@ public class S3TupleSink implements TupleSink {
         this.rotateAfterTuples = rotateAfterTuples;
         this.uploadRetryDelay = uploadRetryDelay;
         this.maxInFlightTuples = maxInFlightTuples;
-        this.inFlightPermits = new Semaphore(maxInFlightTuples);
-        // Byte gate in KiB units (ceil) so a large cap stays within int permit range.
-        this.maxOutstandingUploadBytePermits =
-            (int) Math.min(Integer.MAX_VALUE, (maxOutstandingUploadBytes + UPLOAD_BYTE_PERMIT_UNIT - 1)
-                / UPLOAD_BYTE_PERMIT_UNIT);
+        this.inFlightTuplePermits = new Semaphore(maxInFlightTuples);
+        this.maxInFlightBytePermits = bytesToPermits(maxInFlightTupleBytes);
+        this.inFlightBytePermits = new Semaphore(maxInFlightBytePermits);
+        this.maxOutstandingUploadBytePermits = bytesToPermits(maxOutstandingUploadBytes);
         this.outstandingUploadBytePermits = new Semaphore(maxOutstandingUploadBytePermits);
         this.outstandingUploadFilePermits = new Semaphore(maxOutstandingUploadFiles);
         this.executor = Executors.newSingleThreadScheduledExecutor(makeThreadFactory("worker"));
@@ -241,17 +266,19 @@ public class S3TupleSink implements TupleSink {
 
     @Override
     public void accept(Map<String, Object> tupleMap, CompletableFuture<Void> future) {
-        // Backpressure: block the caller until an in-flight permit is available. When S3 is backed
-        // up this throttles tuple production (replay slows) instead of growing memory without bound
-        // or failing the tuple (which would crash the replayer into a no-progress restart loop).
-        // The permit covers the whole lifecycle and is released exactly once when `future` settles.
-        if (!acquirePermit(future)) {
+        // Backpressure: block the caller until this tuple fits within both the count and byte caps
+        // on in-flight (accepted-but-not-yet-durably-uploaded) tuples. When S3 is backed up this
+        // throttles tuple production (replay slows) instead of growing memory without bound or
+        // failing the tuple (which would crash the replayer into a no-progress restart loop). The
+        // permits cover the whole lifecycle and release exactly once, when `future` settles.
+        int bytePermits = bytesToPermits(estimateTupleBytes(tupleMap));
+        if (!acquireIntakePermits(bytePermits, future)) {
             return;  // interrupted/shutting down — future already completed exceptionally
         }
-        releasePermitWhenSettled(future);
+        releaseIntakePermitsWhenSettled(bytePermits, future);
 
-        // Option A: do NO per-tuple CPU on the calling (event-loop) thread. JSON serialization and
-        // gzip both run on the worker thread; accept() only reserves a permit and enqueues.
+        // Do NO per-tuple CPU on the calling (event-loop) thread: JSON serialization and gzip both
+        // run on the worker thread, so accept() only estimates size, reserves permits, and enqueues.
         runOnWorker(() -> {
             try {
                 byte[] json = mapper.writeValueAsBytes(tupleMap);
@@ -272,14 +299,20 @@ public class S3TupleSink implements TupleSink {
     }
 
     /**
-     * Block until an in-flight permit is available. Returns false (and fails the future) only if
-     * the thread is interrupted — never on cap exhaustion, which just waits, so a transient S3
-     * outage throttles rather than fails. The blocked thread is the replay response-completion
-     * thread, independent of the worker/SDK threads that drain permits, so this can't deadlock.
+     * Block until both an in-flight tuple permit and {@code bytePermits} byte permits are available.
+     * Returns false (and fails the future) only if the thread is interrupted — never on cap
+     * exhaustion, which just waits, so a transient S3 outage throttles rather than fails. The blocked
+     * thread is the replay response-completion thread, independent of the worker/SDK threads that
+     * drain permits, so this can't deadlock. The byte request is clamped to the cap so a single
+     * oversized tuple proceeds solo rather than blocking forever against a too-small cap.
      */
-    private boolean acquirePermit(CompletableFuture<Void> future) {
+    private boolean acquireIntakePermits(int bytePermits, CompletableFuture<Void> future) {
+        int clampedBytePermits = Math.min(bytePermits, maxInFlightBytePermits);
         try {
-            inFlightPermits.acquire();
+            inFlightTuplePermits.acquire();
+            if (clampedBytePermits > 0) {
+                inFlightBytePermits.acquire(clampedBytePermits);
+            }
             return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -288,9 +321,59 @@ public class S3TupleSink implements TupleSink {
         }
     }
 
-    /** Release the in-flight permit exactly once, when the tuple's future settles. */
-    private void releasePermitWhenSettled(CompletableFuture<Void> future) {
-        future.whenComplete((v, t) -> inFlightPermits.release());
+    /** Release the in-flight tuple + byte permits exactly once, when the tuple's future settles. */
+    private void releaseIntakePermitsWhenSettled(int bytePermits, CompletableFuture<Void> future) {
+        int clampedBytePermits = Math.min(bytePermits, maxInFlightBytePermits);
+        future.whenComplete((v, t) -> {
+            inFlightTuplePermits.release();
+            if (clampedBytePermits > 0) {
+                inFlightBytePermits.release(clampedBytePermits);
+            }
+        });
+    }
+
+    /**
+     * Coarse estimate of a tuple's serialized size, used only to bound in-flight heap (the intake
+     * byte gate) — NOT for rotation, which uses the exact compressed byte count. Sums CharSequence
+     * lengths (each O(1)) plus a small fixed charge per node for keys/structure; the bulk of a tuple
+     * is HTTP payload strings, which this captures cheaply. It intentionally ignores
+     * encoding/JSON-escaping overhead; the count cap and the byte-accurate disk gate cover the rest.
+     *
+     * <p>Deliberately iterative with a fixed node budget so it stays cheap on the calling
+     * (event-loop) thread and is immune to deeply-nested or self-referential maps — it walks at most
+     * {@code ESTIMATE_NODE_BUDGET} nodes, under-counting a pathologically large tuple rather than
+     * risking a StackOverflow or a long traversal. (Container values only; it never invokes methods
+     * on scalar/bean values, so estimating a tuple does not trigger its serialization.)</p>
+     */
+    static long estimateTupleBytes(Object root) {
+        long sum = 0;
+        int visited = 0;
+        Deque<Object> stack = new ArrayDeque<>();
+        stack.push(root);
+        while (!stack.isEmpty() && visited < ESTIMATE_NODE_BUDGET) {
+            Object value = stack.pop();
+            visited++;
+            if (value == null) {
+                sum += 4;  // "null"
+            } else if (value instanceof CharSequence) {
+                sum += ((CharSequence) value).length();
+            } else if (value instanceof Map) {
+                for (var entry : ((Map<?, ?>) value).entrySet()) {
+                    sum += 4;  // per-entry structural/key charge
+                    stack.push(entry.getKey());
+                    stack.push(entry.getValue());
+                }
+            } else if (value instanceof Iterable) {
+                for (var element : (Iterable<?>) value) {
+                    sum += 1;
+                    stack.push(element);
+                }
+            } else {
+                // Numbers, booleans, beans, and other scalars: a small fixed charge, no method call.
+                sum += 8;
+            }
+        }
+        return sum;
     }
 
     @Override
@@ -419,9 +502,7 @@ public class S3TupleSink implements TupleSink {
             // Can't size it — don't block on the byte gate for this file; still take a file permit.
             sizeBytes = 0;
         }
-        int bytePermits = (int) Math.min(
-            maxOutstandingUploadBytePermits,
-            (sizeBytes + UPLOAD_BYTE_PERMIT_UNIT - 1) / UPLOAD_BYTE_PERMIT_UNIT);
+        int bytePermits = Math.min(maxOutstandingUploadBytePermits, bytesToPermits(sizeBytes));
         try {
             outstandingUploadFilePermits.acquire();
             if (bytePermits > 0) {
@@ -431,6 +512,15 @@ public class S3TupleSink implements TupleSink {
             Thread.currentThread().interrupt();
         }
         return bytePermits;
+    }
+
+    /**
+     * Convert a byte count to the number of KiB-denominated permits (ceil), clamped to the int
+     * permit range so a multi-GiB cap stays representable. Shared by the intake byte gate and the
+     * disk-backlog byte gate.
+     */
+    private static int bytesToPermits(long bytes) {
+        return (int) Math.min(Integer.MAX_VALUE, (bytes + BYTE_PERMIT_UNIT - 1) / BYTE_PERMIT_UNIT);
     }
 
     private void releaseDiskBacklogPermits(int bytePermits) {

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
@@ -18,13 +18,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPOutputStream;
+
+import org.opensearch.migrations.replay.limiter.ProducerLimiter;
+import org.opensearch.migrations.replay.limiter.WeightedProducerLimiter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -138,19 +140,15 @@ public class S3TupleSink implements TupleSink {
     // (single, parked) worker they could never run → the gate would never drain → deadlock. Keeping
     // retries on their own thread means the worker can park safely.
     private final ScheduledExecutorService uploadRetryScheduler;
-    // Byte-denominated semaphores count permits in KiB units (ceil) so the permit count stays an int
-    // even for multi-GiB caps. Shared by the intake byte gate and the disk-backlog byte gate.
-    private static final long BYTE_PERMIT_UNIT = 1024L;
     // Intake gate: bounds accepted-but-not-yet-durably-uploaded tuples by count AND estimated bytes
-    // (either fills first). See class javadoc.
-    private final Semaphore inFlightTuplePermits;
-    private final Semaphore inFlightBytePermits;
-    private final int maxInFlightTuples;
-    private final int maxInFlightBytePermits;
-    // Disk-backlog gates: bound rotated-but-not-yet-uploaded temp files by total size and count.
-    private final Semaphore outstandingUploadBytePermits;
-    private final Semaphore outstandingUploadFilePermits;
-    private final int maxOutstandingUploadBytePermits;
+    // (either fills first). Released when each tuple future settles. See class javadoc.
+    private final ProducerLimiter intakeTupleLimiter;
+    private final ProducerLimiter intakeByteLimiter;
+    // Disk-backlog gate: bounds rotated-but-not-yet-uploaded temp files by count AND total size.
+    // Released on upload success — and that release MUST run off the worker thread (see the
+    // uploadRetryScheduler note above), because the worker parks on this gate inside rotate().
+    private final ProducerLimiter diskFileLimiter;
+    private final ProducerLimiter diskByteLimiter;
     private final AtomicInteger activeUploads = new AtomicInteger();
     private final AtomicBoolean closeRequested = new AtomicBoolean();
     private final AtomicLong sequenceCounter = new AtomicLong();
@@ -244,13 +242,10 @@ public class S3TupleSink implements TupleSink {
         this.rotateAfterAge = rotateAfterAge;
         this.rotateAfterTuples = rotateAfterTuples;
         this.uploadRetryDelay = uploadRetryDelay;
-        this.maxInFlightTuples = maxInFlightTuples;
-        this.inFlightTuplePermits = new Semaphore(maxInFlightTuples);
-        this.maxInFlightBytePermits = bytesToPermits(maxInFlightTupleBytes);
-        this.inFlightBytePermits = new Semaphore(maxInFlightBytePermits);
-        this.maxOutstandingUploadBytePermits = bytesToPermits(maxOutstandingUploadBytes);
-        this.outstandingUploadBytePermits = new Semaphore(maxOutstandingUploadBytePermits);
-        this.outstandingUploadFilePermits = new Semaphore(maxOutstandingUploadFiles);
+        this.intakeTupleLimiter = WeightedProducerLimiter.ofCount("s3-intake-tuples-" + sinkIndex, maxInFlightTuples);
+        this.intakeByteLimiter = WeightedProducerLimiter.ofBytes("s3-intake-bytes-" + sinkIndex, maxInFlightTupleBytes);
+        this.diskFileLimiter = WeightedProducerLimiter.ofCount("s3-disk-files-" + sinkIndex, maxOutstandingUploadFiles);
+        this.diskByteLimiter = WeightedProducerLimiter.ofBytes("s3-disk-bytes-" + sinkIndex, maxOutstandingUploadBytes);
         this.executor = Executors.newSingleThreadScheduledExecutor(makeThreadFactory("worker"));
         this.uploadRetryScheduler = Executors.newSingleThreadScheduledExecutor(makeThreadFactory("upload-retry"));
         openNewStream();
@@ -270,12 +265,10 @@ public class S3TupleSink implements TupleSink {
         // on in-flight (accepted-but-not-yet-durably-uploaded) tuples. When S3 is backed up this
         // throttles tuple production (replay slows) instead of growing memory without bound or
         // failing the tuple (which would crash the replayer into a no-progress restart loop). The
-        // permits cover the whole lifecycle and release exactly once, when `future` settles.
-        int bytePermits = bytesToPermits(estimateTupleBytes(tupleMap));
-        if (!acquireIntakePermits(bytePermits, future)) {
+        // reservations cover the whole lifecycle and release exactly once, when `future` settles.
+        if (!reserveIntakeUntilSettled(estimateTupleBytes(tupleMap), future)) {
             return;  // interrupted/shutting down — future already completed exceptionally
         }
-        releaseIntakePermitsWhenSettled(bytePermits, future);
 
         // Do NO per-tuple CPU on the calling (event-loop) thread: JSON serialization and gzip both
         // run on the worker thread, so accept() only estimates size, reserves permits, and enqueues.
@@ -299,37 +292,29 @@ public class S3TupleSink implements TupleSink {
     }
 
     /**
-     * Block until both an in-flight tuple permit and {@code bytePermits} byte permits are available.
-     * Returns false (and fails the future) only if the thread is interrupted — never on cap
-     * exhaustion, which just waits, so a transient S3 outage throttles rather than fails. The blocked
-     * thread is the replay response-completion thread, independent of the worker/SDK threads that
-     * drain permits, so this can't deadlock. The byte request is clamped to the cap so a single
-     * oversized tuple proceeds solo rather than blocking forever against a too-small cap.
+     * Reserve both intake dimensions (one tuple + its estimated bytes) and release both exactly once
+     * when {@code future} settles. Both reservations are taken BEFORE registering the release so an
+     * interrupt mid-way frees the one already held; if interrupted, the future is completed
+     * exceptionally and false is returned. Blocking here parks the replay response-completion thread,
+     * which is independent of the worker/SDK threads that drain the gates, so it can't deadlock.
      */
-    private boolean acquireIntakePermits(int bytePermits, CompletableFuture<Void> future) {
-        int clampedBytePermits = Math.min(bytePermits, maxInFlightBytePermits);
-        try {
-            inFlightTuplePermits.acquire();
-            if (clampedBytePermits > 0) {
-                inFlightBytePermits.acquire(clampedBytePermits);
-            }
-            return true;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            future.completeExceptionally(e);
+    private boolean reserveIntakeUntilSettled(long estimatedBytes, CompletableFuture<Void> future) {
+        var tupleReservation = intakeTupleLimiter.reserve(1);
+        if (tupleReservation.isEmpty()) {
+            future.completeExceptionally(new InterruptedException("interrupted reserving intake tuple permit"));
             return false;
         }
-    }
-
-    /** Release the in-flight tuple + byte permits exactly once, when the tuple's future settles. */
-    private void releaseIntakePermitsWhenSettled(int bytePermits, CompletableFuture<Void> future) {
-        int clampedBytePermits = Math.min(bytePermits, maxInFlightBytePermits);
+        var byteReservation = intakeByteLimiter.reserve(estimatedBytes);
+        if (byteReservation.isEmpty()) {
+            tupleReservation.get().release();
+            future.completeExceptionally(new InterruptedException("interrupted reserving intake byte permits"));
+            return false;
+        }
         future.whenComplete((v, t) -> {
-            inFlightTuplePermits.release();
-            if (clampedBytePermits > 0) {
-                inFlightBytePermits.release(clampedBytePermits);
-            }
+            tupleReservation.get().release();
+            byteReservation.get().release();
         });
+        return true;
     }
 
     /**
@@ -470,15 +455,16 @@ public class S3TupleSink implements TupleSink {
         }
 
         // Disk-backlog gate: block the worker until the rotated file fits within the outstanding-
-        // upload caps (bytes + file count). This is the byte-accurate bound that protects /tmp from
+        // upload caps (file count + bytes). This is the byte-accurate bound that protects /tmp from
         // a sustained S3 outage; the worker parking here also pauses new writes + the age flush
-        // (intended backpressure). Permits are released on upload success (see uploadFileWithRetries).
-        var bytePermits = acquireDiskBacklogPermits(file);
+        // (intended backpressure). Reservations are released on upload success (see
+        // uploadFileWithRetries) — on a thread OTHER than this worker, so the parked worker can drain.
+        var diskReservations = acquireDiskBacklogReservations(file);
 
         log.atInfo().setMessage("Completing S3 upload to s3://{}/{}").addArgument(bucket).addArgument(key).log();
 
         activeUploads.incrementAndGet();
-        uploadFileWithRetries(key, file, futures, bytePermits, 1);
+        uploadFileWithRetries(key, file, futures, diskReservations, 1);
 
         if (openNextStream) {
             openNewStream();
@@ -489,12 +475,12 @@ public class S3TupleSink implements TupleSink {
 
     /**
      * Block (on the worker thread) until the just-finished file fits within the outstanding-upload
-     * byte + file caps, then return the number of byte permits reserved (to release on success). A
-     * file larger than the whole byte cap is clamped to the cap so it can still proceed solo rather
-     * than deadlock. Interruption (shutdown) returns the clamped count without having acquired, so
-     * release stays balanced.
+     * file-count and byte caps, then return the held reservations (to release on upload success).
+     * Acquire order is file-then-bytes; an oversized file is clamped to the byte cap by the limiter
+     * so it proceeds solo rather than deadlock. On interrupt (shutdown) a reservation may be empty;
+     * releasing an empty reservation is a no-op, so release stays balanced.
      */
-    private int acquireDiskBacklogPermits(Path file) {
+    private DiskBacklogReservations acquireDiskBacklogReservations(Path file) {
         long sizeBytes;
         try {
             sizeBytes = Files.size(file);
@@ -502,31 +488,31 @@ public class S3TupleSink implements TupleSink {
             // Can't size it — don't block on the byte gate for this file; still take a file permit.
             sizeBytes = 0;
         }
-        int bytePermits = Math.min(maxOutstandingUploadBytePermits, bytesToPermits(sizeBytes));
-        try {
-            outstandingUploadFilePermits.acquire();
-            if (bytePermits > 0) {
-                outstandingUploadBytePermits.acquire(bytePermits);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+        // Acquire file-then-bytes (consistent order; releasers never acquire → no deadlock). A null
+        // reservation (interrupted, or size unknown for the byte gate) releases as a no-op.
+        var fileReservation = diskFileLimiter.reserve(1).orElse(null);
+        var byteReservation = sizeBytes > 0 ? diskByteLimiter.reserve(sizeBytes).orElse(null) : null;
+        return new DiskBacklogReservations(fileReservation, byteReservation);
+    }
+
+    /** Held file + byte reservations for one in-flight upload; released together on success. */
+    private static final class DiskBacklogReservations {
+        private final ProducerLimiter.Reservation fileReservation;
+        private final ProducerLimiter.Reservation byteReservation;
+
+        DiskBacklogReservations(ProducerLimiter.Reservation fileReservation,
+                                ProducerLimiter.Reservation byteReservation) {
+            this.fileReservation = fileReservation;
+            this.byteReservation = byteReservation;
         }
-        return bytePermits;
-    }
 
-    /**
-     * Convert a byte count to the number of KiB-denominated permits (ceil), clamped to the int
-     * permit range so a multi-GiB cap stays representable. Shared by the intake byte gate and the
-     * disk-backlog byte gate.
-     */
-    private static int bytesToPermits(long bytes) {
-        return (int) Math.min(Integer.MAX_VALUE, (bytes + BYTE_PERMIT_UNIT - 1) / BYTE_PERMIT_UNIT);
-    }
-
-    private void releaseDiskBacklogPermits(int bytePermits) {
-        outstandingUploadFilePermits.release();
-        if (bytePermits > 0) {
-            outstandingUploadBytePermits.release(bytePermits);
+        void release() {
+            if (fileReservation != null) {
+                fileReservation.release();
+            }
+            if (byteReservation != null) {
+                byteReservation.release();
+            }
         }
     }
 
@@ -579,7 +565,7 @@ public class S3TupleSink implements TupleSink {
         String key,
         Path file,
         List<CompletableFuture<Void>> futures,
-        int diskBacklogBytePermits,
+        DiskBacklogReservations diskReservations,
         int attempt
     ) {
         uploadFile(key, file).whenComplete((response, error) -> {
@@ -587,7 +573,8 @@ public class S3TupleSink implements TupleSink {
                 deleteFile(file);
                 // Release the disk-backlog gate first: the file is gone and its futures are about
                 // to complete, so unblock the worker (which may be parked in rotate()) promptly.
-                releaseDiskBacklogPermits(diskBacklogBytePermits);
+                // This runs on an SDK/retry thread, never the worker, so the parked worker can drain.
+                diskReservations.release();
                 futures.forEach(f -> f.complete(null));
                 activeUploads.decrementAndGet();
                 shutdownExecutorIfDone();
@@ -602,7 +589,7 @@ public class S3TupleSink implements TupleSink {
                 .addArgument(uploadRetryDelay::toMillis)
                 .log();
             uploadRetryScheduler.schedule(
-                () -> uploadFileWithRetries(key, file, futures, diskBacklogBytePermits, attempt + 1),
+                () -> uploadFileWithRetries(key, file, futures, diskReservations, attempt + 1),
                 uploadRetryDelay.toMillis(),
                 TimeUnit.MILLISECONDS
             );

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,10 +43,34 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  *
  * <p>Each instance is single-threaded (one per Netty event loop). The {@code sinkIndex}
  * is embedded in keys to avoid collisions between concurrent writers.</p>
+ *
+ * <p><b>Threading.</b> {@code accept()} does no work on the calling (Netty event-loop) thread
+ * beyond reserving an in-flight permit and enqueueing — JSON serialization, gzip, and disk I/O
+ * all run on the sink's single worker thread. This keeps request replay off the critical path.</p>
+ *
+ * <p><b>Backpressure (block, don't fail).</b> S3 upload failures retry indefinitely so replay
+ * progress stays tied to durable output. Failing a tuple future is NOT an option for transient
+ * pressure: a failed tuple write is fatal to the replayer and it shuts down WITHOUT committing the
+ * held offsets (TrafficReplayerCore.failReplayForTupleWrite), so on restart it resumes at the same
+ * offset, re-reads the same tuples, and — if S3 is still down — crash-loops forever, never
+ * advancing. So instead we apply real backpressure: a semaphore caps accepted-but-not-yet-durably-
+ * uploaded tuples at {@code maxInFlightTuples}, and when the cap is reached {@code accept()} BLOCKS
+ * the calling thread until a permit frees (i.e. until an in-flight upload completes). This bounds
+ * memory (buffered tuples + temp files + pending futures) while letting the replayer ride out an S3
+ * outage and resume — throughput drops to zero during the outage by design, rather than failing.
+ * The blocking happens on the replay response-completion thread, which is independent of the S3 SDK
+ * threads and the sink's worker thread, so the upload/retry machinery keeps draining (no deadlock).
+ * Permits are released when each tuple's future settles.</p>
  */
 @Slf4j
 public class S3TupleSink implements TupleSink {
     static final Duration DEFAULT_UPLOAD_RETRY_DELAY = Duration.ofSeconds(10);
+
+    /**
+     * Default cap on accepted-but-not-yet-durably-uploaded tuples. Bounds memory under a sustained
+     * S3 outage; when reached, accept() blocks (waits for an upload to drain) rather than failing.
+     */
+    static final int DEFAULT_MAX_IN_FLIGHT_TUPLES = 100_000;
 
     private static final DateTimeFormatter TIMESTAMP_FORMAT =
         DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
@@ -63,12 +88,15 @@ public class S3TupleSink implements TupleSink {
     private final int rotateAfterTuples;
     private final Duration uploadRetryDelay;
     // Single work thread that owns ALL buffer state (gzipOut / pendingFutures / currentFile /
-    // counters). accept()/flush()/close() marshal onto it, and it self-schedules the age-based
-    // flush. Because every buffer mutation runs on this one thread, no lock is needed — this is
-    // the sink's own "event loop". (The async S3 upload callback runs on an SDK thread but only
-    // touches atomics, never buffer state.) This also frees the Netty event loop from the
-    // gzip/serialize work that accept() used to do inline.
+    // counters) AND all CPU work (JSON serialization + gzip). accept()/flush()/close() marshal
+    // onto it, and it self-schedules the age-based flush. Because every buffer mutation runs on
+    // this one thread, no lock is needed — this is the sink's own "event loop". (The async S3
+    // upload callback runs on an SDK thread but only touches atomics, never buffer state.) This
+    // keeps the Netty event loop free of all per-tuple serialize/gzip/disk work.
     private final ScheduledExecutorService executor;
+    // Bounds accepted-but-not-yet-durably-uploaded tuples. See class javadoc (Backpressure).
+    private final Semaphore inFlightPermits;
+    private final int maxInFlightTuples;
     private final AtomicInteger activeUploads = new AtomicInteger();
     private final AtomicBoolean closeRequested = new AtomicBoolean();
     private final AtomicLong sequenceCounter = new AtomicLong();
@@ -101,7 +129,8 @@ public class S3TupleSink implements TupleSink {
             rotateAfterBytes,
             rotateAfterAge,
             rotateAfterTuples,
-            DEFAULT_UPLOAD_RETRY_DELAY
+            DEFAULT_UPLOAD_RETRY_DELAY,
+            DEFAULT_MAX_IN_FLIGHT_TUPLES
         );
     }
 
@@ -116,6 +145,22 @@ public class S3TupleSink implements TupleSink {
         int rotateAfterTuples,
         Duration uploadRetryDelay
     ) {
+        this(s3Client, bucket, prefix, replayerId, sinkIndex, rotateAfterBytes, rotateAfterAge,
+            rotateAfterTuples, uploadRetryDelay, DEFAULT_MAX_IN_FLIGHT_TUPLES);
+    }
+
+    S3TupleSink(
+        S3AsyncClient s3Client,
+        String bucket,
+        String prefix,
+        String replayerId,
+        int sinkIndex,
+        long rotateAfterBytes,
+        Duration rotateAfterAge,
+        int rotateAfterTuples,
+        Duration uploadRetryDelay,
+        int maxInFlightTuples
+    ) {
         this.s3Client = s3Client;
         this.bucket = bucket;
         this.prefix = prefix;
@@ -125,6 +170,8 @@ public class S3TupleSink implements TupleSink {
         this.rotateAfterAge = rotateAfterAge;
         this.rotateAfterTuples = rotateAfterTuples;
         this.uploadRetryDelay = uploadRetryDelay;
+        this.maxInFlightTuples = maxInFlightTuples;
+        this.inFlightPermits = new Semaphore(maxInFlightTuples);
         this.executor = Executors.newSingleThreadScheduledExecutor(makeWorkerThreadFactory());
         openNewStream();
         // Self-scheduled age flush: re-checks file age on its own thread so a sink that stops
@@ -139,24 +186,27 @@ public class S3TupleSink implements TupleSink {
 
     @Override
     public void accept(Map<String, Object> tupleMap, CompletableFuture<Void> future) {
-        // Serialize the tuple on the calling (event-loop) thread so a serialization failure can
-        // be reported synchronously and the tupleMap isn't retained across threads. The actual
-        // buffer write is marshalled onto the worker thread.
-        final byte[] json;
-        try {
-            json = mapper.writeValueAsBytes(tupleMap);
-        } catch (IOException e) {
-            future.completeExceptionally(e);
-            return;
+        // Backpressure: block the caller until an in-flight permit is available. When S3 is backed
+        // up this throttles tuple production (replay slows) instead of growing memory without bound
+        // or failing the tuple (which would crash the replayer into a no-progress restart loop).
+        // The permit covers the whole lifecycle and is released exactly once when `future` settles.
+        if (!acquirePermit(future)) {
+            return;  // interrupted/shutting down — future already completed exceptionally
         }
+        releasePermitWhenSettled(future);
+
+        // Option A: do NO per-tuple CPU on the calling (event-loop) thread. JSON serialization and
+        // gzip both run on the worker thread; accept() only reserves a permit and enqueues.
         runOnWorker(() -> {
             try {
+                byte[] json = mapper.writeValueAsBytes(tupleMap);
                 gzipOut.write(json);
                 gzipOut.write('\n');
                 uncompressedBytes += json.length + 1;
                 tupleCount++;
                 pendingFutures.add(future);
             } catch (IOException e) {
+                // Serialization/gzip failure is per-tuple and not helped by retry — fail it.
                 future.completeExceptionally(e);
                 return;
             }
@@ -164,6 +214,28 @@ public class S3TupleSink implements TupleSink {
                 rotate(true);
             }
         }, future);
+    }
+
+    /**
+     * Block until an in-flight permit is available. Returns false (and fails the future) only if
+     * the thread is interrupted — never on cap exhaustion, which just waits, so a transient S3
+     * outage throttles rather than fails. The blocked thread is the replay response-completion
+     * thread, independent of the worker/SDK threads that drain permits, so this can't deadlock.
+     */
+    private boolean acquirePermit(CompletableFuture<Void> future) {
+        try {
+            inFlightPermits.acquire();
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            future.completeExceptionally(e);
+            return false;
+        }
+    }
+
+    /** Release the in-flight permit exactly once, when the tuple's future settles. */
+    private void releasePermitWhenSettled(CompletableFuture<Void> future) {
+        future.whenComplete((v, t) -> inFlightPermits.release());
     }
 
     @Override

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
@@ -92,11 +92,11 @@ public class S3TupleSink implements TupleSink {
 
     /**
      * Default intake-gate cap on the estimated bytes of accepted-but-not-yet-durably-uploaded tuples
-     * (256 MiB). Guards against a small number of very large tuples (big request/response payloads)
+     * (2 GiB). Guards against a small number of very large tuples (big request/response payloads)
      * blowing the heap before the count cap above would trip. Coarse by design — see
      * {@link #estimateTupleBytes}.
      */
-    static final long DEFAULT_MAX_IN_FLIGHT_TUPLE_BYTES = 256L * 1024L * 1024L;
+    static final long DEFAULT_MAX_IN_FLIGHT_TUPLE_BYTES = 2L * 1024L * 1024L * 1024L;
 
     /** Default disk-backlog cap on bytes of rotated-but-not-yet-uploaded temp files (1 GiB). */
     static final long DEFAULT_MAX_OUTSTANDING_UPLOAD_BYTES = 1024L * 1024L * 1024L;

--- a/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/limiter/WeightedBlockingGateTest.java
+++ b/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/limiter/WeightedBlockingGateTest.java
@@ -1,0 +1,78 @@
+package org.opensearch.migrations.replay.limiter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WeightedBlockingGateTest {
+
+    @Test
+    void countGateConvertsWeightOneToOnePermit() {
+        var gate = WeightedBlockingGate.ofCount("count", 10);
+        assertEquals(10, gate.capacityPermits());
+        assertEquals(3, gate.permitsFor(3));
+        assertEquals(0, gate.permitsFor(0));
+    }
+
+    @Test
+    void byteGateIsKiBDenominatedAndRoundsUp() {
+        // 4 KiB capacity -> 4 permits; sub-KiB and partial-KiB weights round up.
+        var gate = WeightedBlockingGate.ofBytes("bytes", 4L * 1024L);
+        assertEquals(4, gate.capacityPermits());
+        assertEquals(1, gate.permitsFor(1));      // 1 byte -> 1 KiB permit
+        assertEquals(1, gate.permitsFor(1024));   // exactly 1 KiB -> 1 permit
+        assertEquals(2, gate.permitsFor(1025));   // 1 KiB + 1 byte -> 2 permits (ceil)
+    }
+
+    @Test
+    void permitsForClampsOversizedRequestToCapacitySoItCanProceedSolo() {
+        var gate = WeightedBlockingGate.ofBytes("bytes", 2L * 1024L);  // 2 permits
+        assertEquals(2, gate.permitsFor(100L * 1024L * 1024L));        // 100 MiB clamps to capacity
+    }
+
+    @Test
+    void acquireAndReleaseTrackAvailablePermits() {
+        var gate = WeightedBlockingGate.ofCount("count", 5);
+        assertEquals(5, gate.availablePermits());
+
+        assertTrue(gate.acquire(3));
+        assertEquals(2, gate.availablePermits());
+
+        gate.release(3);
+        assertEquals(5, gate.availablePermits());
+    }
+
+    @Test
+    void acquireAndReleaseOfNonPositiveAreNoOps() {
+        var gate = WeightedBlockingGate.ofCount("count", 5);
+        assertTrue(gate.acquire(0));
+        assertTrue(gate.acquire(-1));
+        gate.release(0);
+        gate.release(-1);
+        assertEquals(5, gate.availablePermits());
+    }
+
+    @Test
+    void acquireReturnsFalseAndSetsInterruptFlagWhenInterruptedWhileWaiting() throws Exception {
+        var gate = WeightedBlockingGate.ofCount("count", 1);
+        assertTrue(gate.acquire(1));  // exhaust the single permit
+
+        var acquired = new java.util.concurrent.atomic.AtomicBoolean(true);
+        var interruptFlagObserved = new java.util.concurrent.atomic.AtomicBoolean(false);
+        var t = new Thread(() -> {
+            boolean ok = gate.acquire(1);  // must block (no permits), then be interrupted
+            acquired.set(ok);
+            interruptFlagObserved.set(Thread.currentThread().isInterrupted());
+        }, "gate-waiter");
+        t.start();
+        // Give it a moment to park on the semaphore, then interrupt.
+        Thread.sleep(100);
+        t.interrupt();
+        t.join(2000);
+
+        assertFalse(acquired.get(), "acquire should return false when interrupted while waiting");
+        assertTrue(interruptFlagObserved.get(), "interrupt flag should be re-set after a false return");
+    }
+}

--- a/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/limiter/WeightedProducerLimiterTest.java
+++ b/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/limiter/WeightedProducerLimiterTest.java
@@ -1,0 +1,87 @@
+package org.opensearch.migrations.replay.limiter;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WeightedProducerLimiterTest {
+
+    @Test
+    void reserveBlocksWhenExhaustedThenProceedsOnRelease() throws Exception {
+        var limiter = WeightedProducerLimiter.ofCount("count", 1);
+        var first = limiter.reserve(1).orElseThrow();  // consume the only permit
+
+        var secondReserved = new CompletableFuture<Void>();
+        var t = new Thread(() -> {
+            limiter.reserve(1).orElseThrow();  // must block until `first` is released
+            secondReserved.complete(null);
+        }, "second-reserve");
+        t.start();
+
+        assertThrows(TimeoutException.class,
+            () -> secondReserved.get(500, TimeUnit.MILLISECONDS),
+            "second reserve should block while the limiter is exhausted");
+
+        first.release();
+        secondReserved.get(2, TimeUnit.SECONDS);
+        t.join(2000);
+    }
+
+    @Test
+    void releaseIsIdempotentAndDoesNotOverCreditCapacity() {
+        var gate = WeightedBlockingGate.ofCount("count", 2);
+        var limiter = new WeightedProducerLimiter(gate);
+
+        var reservation = limiter.reserve(1).orElseThrow();
+        assertEquals(1, gate.availablePermits());
+
+        reservation.release();
+        assertEquals(2, gate.availablePermits());
+        reservation.release();  // second release must be a no-op
+        assertEquals(2, gate.availablePermits(), "double release must not exceed capacity");
+    }
+
+    @Test
+    void reserveUntilSettledReleasesOnNormalCompletion() throws Exception {
+        var gate = WeightedBlockingGate.ofCount("count", 1);
+        var limiter = new WeightedProducerLimiter(gate);
+        var future = new CompletableFuture<Void>();
+
+        assertTrue(limiter.reserveUntilSettled(1, future));
+        assertEquals(0, gate.availablePermits());
+
+        future.complete(null);
+        assertEquals(1, gate.availablePermits());
+    }
+
+    @Test
+    void reserveUntilSettledReleasesOnExceptionalCompletion() throws Exception {
+        var gate = WeightedBlockingGate.ofCount("count", 1);
+        var limiter = new WeightedProducerLimiter(gate);
+        var future = new CompletableFuture<Void>();
+
+        assertTrue(limiter.reserveUntilSettled(1, future));
+        assertEquals(0, gate.availablePermits());
+
+        future.completeExceptionally(new RuntimeException("boom"));
+        assertEquals(1, gate.availablePermits(), "permits must be returned even on failure");
+    }
+
+    @Test
+    void oversizedWeightClampsToCapacityAndProceedsSolo() {
+        var gate = WeightedBlockingGate.ofBytes("bytes", 2L * 1024L);  // 2 KiB permits
+        var limiter = new WeightedProducerLimiter(gate);
+
+        // A request far larger than the whole gate must still succeed (clamped), not block forever.
+        var reservation = limiter.reserve(100L * 1024L * 1024L).orElseThrow();
+        assertEquals(0, gate.availablePermits());
+        reservation.release();
+        assertEquals(2, gate.availablePermits());
+    }
+}

--- a/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
+++ b/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
@@ -36,6 +36,12 @@ class S3TupleSinkTest {
         return map;
     }
 
+    private Map<String, Object> makeTupleWithPayload(String id, String payload) {
+        var map = makeTuple(id);
+        map.put("payload", payload);
+        return map;
+    }
+
     @Test
     void flushWithoutPendingTuplesDoesNotUpload() {
         var s3Client = mock(S3AsyncClient.class);
@@ -57,7 +63,7 @@ class S3TupleSinkTest {
             var future = new CompletableFuture<Void>();
             sink.accept(recursiveTuple, future);
 
-            // Serialization now runs on the worker thread (Option A), so completion is async —
+            // Serialization runs on the worker thread, so completion is async —
             // await it rather than asserting synchronously right after accept().
             var ex = assertThrows(ExecutionException.class, () -> future.get(2, TimeUnit.SECONDS));
             assertTrue(ex.getCause() instanceof IOException);
@@ -68,21 +74,26 @@ class S3TupleSinkTest {
 
     @Test
     void serializationRunsOffTheCallingThread() throws Exception {
-        // Option A: accept() must not serialize on the calling thread. A tuple whose toString/
-        // serialization would run on the worker should leave the calling thread immediately.
+        // accept() must not serialize on the calling thread: a tuple's serialization runs on the
+        // worker, so the calling (event-loop) thread should be released immediately.
         var s3Client = mock(S3AsyncClient.class);
         var callingThread = Thread.currentThread().getName();
         var serializeThread = new java.util.concurrent.CompletableFuture<String>();
 
-        // A Map whose entry iteration records the serializing thread.
-        var probeTuple = new LinkedHashMap<String, Object>() {
-            @Override
-            public java.util.Set<Map.Entry<String, Object>> entrySet() {
+        // A scalar VALUE whose Jackson serialization (getValue) records the thread. Using a value
+        // (not a Map override) ensures we capture true JSON serialization, not the cheap structural
+        // size estimate accept() runs on the calling thread — the estimator never invokes value
+        // getters, so only the worker-thread serialize trips this.
+        var probeValue = new Object() {
+            @com.fasterxml.jackson.annotation.JsonValue
+            public String getValue() {
                 serializeThread.complete(Thread.currentThread().getName());
-                return super.entrySet();
+                return "probe";
             }
         };
+        var probeTuple = new LinkedHashMap<String, Object>();
         probeTuple.put("connectionId", "probe.0");
+        probeTuple.put("probe", probeValue);
 
         try (var sink = makeSink(s3Client, 100)) {
             sink.accept(probeTuple, new CompletableFuture<>());
@@ -128,6 +139,63 @@ class S3TupleSinkTest {
             secondAcceptReturned.get(2, TimeUnit.SECONDS);
             t.join(2000);
         }
+    }
+
+    @Test
+    void acceptBlocksWhenInFlightByteCapExhaustedThenProceedsAsUploadsDrain() throws Exception {
+        var s3Client = mock(S3AsyncClient.class);
+        var upload = new CompletableFuture<PutObjectResponse>();
+        when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(upload);
+
+        // Generous tuple-count cap so the BYTE gate is what blocks. Byte cap = 2 KiB; each tuple's
+        // payload is ~1.5 KiB, so the first tuple fits but the second can't until the first drains.
+        var bigPayload = "x".repeat(1500);
+        try (var sink = makeSink(s3Client, /*rotateAfterTuples*/ 1, Duration.ofMinutes(10),
+                                 /*maxInFlight*/ 1000, /*maxInFlightTupleBytes*/ 2048L,
+                                 S3TupleSink.DEFAULT_MAX_OUTSTANDING_UPLOAD_BYTES,
+                                 S3TupleSink.DEFAULT_MAX_OUTSTANDING_UPLOAD_FILES)) {
+            var f1 = new CompletableFuture<Void>();
+            sink.accept(makeTupleWithPayload("conn1.0", bigPayload), f1);
+
+            // Second accept on a separate thread; it should BLOCK on the byte gate (first tuple's
+            // ~1.5 KiB leaves <1.5 KiB free under the 2 KiB cap), held until f1's upload drains.
+            var f2 = new CompletableFuture<Void>();
+            var secondAcceptReturned = new CompletableFuture<Void>();
+            var t = new Thread(() -> {
+                sink.accept(makeTupleWithPayload("conn2.0", bigPayload), f2);
+                secondAcceptReturned.complete(null);
+            }, "second-accept-bytes");
+            t.start();
+
+            assertThrows(TimeoutException.class,
+                () -> secondAcceptReturned.get(500, TimeUnit.MILLISECONDS),
+                "second accept should block while the in-flight BYTE cap is exhausted");
+
+            // Drain the first upload → releases the byte permits → second accept proceeds.
+            upload.complete(PutObjectResponse.builder().build());
+            f1.get(2, TimeUnit.SECONDS);
+            secondAcceptReturned.get(2, TimeUnit.SECONDS);
+            t.join(2000);
+        }
+    }
+
+    @Test
+    void estimateTupleBytesIsCoarseStructuralSum() {
+        // CharSequence values dominate (counted by length); a nested map + list sums children.
+        var tuple = new LinkedHashMap<String, Object>();
+        tuple.put("connectionId", "conn.0");
+        tuple.put("payload", "x".repeat(1000));
+        var nested = new LinkedHashMap<String, Object>();
+        nested.put("k", "value");
+        tuple.put("nested", nested);
+        tuple.put("list", java.util.List.of("a", "bb"));
+
+        long estimate = S3TupleSink.estimateTupleBytes(tuple);
+        // Must be dominated by the 1000-char payload and strictly exceed the sum of string lengths.
+        long stringChars = "conn.0".length() + 1000 + "value".length() + "a".length() + "bb".length();
+        assertTrue(estimate > stringChars, "estimate should exceed bare string length sum: " + estimate);
+        assertTrue(estimate < stringChars + 200, "estimate should stay coarse/cheap, not balloon: " + estimate);
     }
 
     @Test
@@ -291,12 +359,20 @@ class S3TupleSinkTest {
     private S3TupleSink makeSink(S3AsyncClient s3Client, int rotateAfterTuples, Duration rotateAfterAge,
                                  int maxInFlightTuples) {
         return makeSink(s3Client, rotateAfterTuples, rotateAfterAge, maxInFlightTuples,
+            S3TupleSink.DEFAULT_MAX_IN_FLIGHT_TUPLE_BYTES,
             S3TupleSink.DEFAULT_MAX_OUTSTANDING_UPLOAD_BYTES, S3TupleSink.DEFAULT_MAX_OUTSTANDING_UPLOAD_FILES);
     }
 
     private S3TupleSink makeSink(S3AsyncClient s3Client, int rotateAfterTuples, Duration rotateAfterAge,
                                  int maxInFlightTuples, long maxOutstandingUploadBytes,
                                  int maxOutstandingUploadFiles) {
+        return makeSink(s3Client, rotateAfterTuples, rotateAfterAge, maxInFlightTuples,
+            S3TupleSink.DEFAULT_MAX_IN_FLIGHT_TUPLE_BYTES, maxOutstandingUploadBytes, maxOutstandingUploadFiles);
+    }
+
+    private S3TupleSink makeSink(S3AsyncClient s3Client, int rotateAfterTuples, Duration rotateAfterAge,
+                                 int maxInFlightTuples, long maxInFlightTupleBytes,
+                                 long maxOutstandingUploadBytes, int maxOutstandingUploadFiles) {
         return new S3TupleSink(
             s3Client,
             "bucket",
@@ -308,6 +384,7 @@ class S3TupleSinkTest {
             rotateAfterTuples,
             Duration.ofMillis(10),
             maxInFlightTuples,
+            maxInFlightTupleBytes,
             maxOutstandingUploadBytes,
             maxOutstandingUploadFiles
         );

--- a/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
+++ b/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
@@ -233,6 +233,45 @@ class S3TupleSinkTest {
         }
     }
 
+    @Test
+    void diskBacklogGateBlocksWorkerWhenOutstandingFilesExceedCapThenDrains() throws Exception {
+        var s3Client = mock(S3AsyncClient.class);
+        var firstUpload = new CompletableFuture<PutObjectResponse>();
+        var secondUpload = new CompletableFuture<PutObjectResponse>();
+        var putCallCount = new AtomicInteger();
+        when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenAnswer(invocation -> putCallCount.incrementAndGet() == 1 ? firstUpload : secondUpload);
+
+        // rotate every tuple; intake cap is generous so the DISK gate (max 1 outstanding file) is
+        // what blocks; large byte cap so only the file-count gate is exercised here.
+        try (var sink = makeSink(s3Client, /*rotateAfterTuples*/ 1, Duration.ofMinutes(10),
+                                 /*maxInFlight*/ 1000,
+                                 /*maxOutstandingUploadBytes*/ 1024L * 1024L * 1024L,
+                                 /*maxOutstandingUploadFiles*/ 1)) {
+            var f1 = new CompletableFuture<Void>();
+            sink.accept(makeTuple("conn1.0"), f1);
+            // First file rotates and starts uploading (held open) — consumes the only file permit.
+            waitForPutCalls(putCallCount, 1);
+
+            // Second tuple: it gets buffered+rotated on the worker, which must then BLOCK acquiring
+            // the disk file-permit. So no second putObject happens while the first upload is open.
+            var f2 = new CompletableFuture<Void>();
+            sink.accept(makeTuple("conn2.0"), f2);
+            Thread.sleep(300);
+            assertEquals(1, putCallCount.get(),
+                "worker should be parked on the disk-backlog gate; no 2nd upload until the 1st drains");
+            assertFalse(f2.isDone());
+
+            // Complete the first upload → releases the file permit → worker proceeds to upload #2.
+            firstUpload.complete(PutObjectResponse.builder().build());
+            f1.get(2, TimeUnit.SECONDS);
+            waitForPutCalls(putCallCount, 2);
+
+            secondUpload.complete(PutObjectResponse.builder().build());
+            f2.get(2, TimeUnit.SECONDS);
+        }
+    }
+
     private void waitForPutCalls(AtomicInteger putCallCount, int expectedCalls) throws InterruptedException {
         var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
         while (putCallCount.get() < expectedCalls && System.nanoTime() < deadline) {
@@ -251,6 +290,13 @@ class S3TupleSinkTest {
 
     private S3TupleSink makeSink(S3AsyncClient s3Client, int rotateAfterTuples, Duration rotateAfterAge,
                                  int maxInFlightTuples) {
+        return makeSink(s3Client, rotateAfterTuples, rotateAfterAge, maxInFlightTuples,
+            S3TupleSink.DEFAULT_MAX_OUTSTANDING_UPLOAD_BYTES, S3TupleSink.DEFAULT_MAX_OUTSTANDING_UPLOAD_FILES);
+    }
+
+    private S3TupleSink makeSink(S3AsyncClient s3Client, int rotateAfterTuples, Duration rotateAfterAge,
+                                 int maxInFlightTuples, long maxOutstandingUploadBytes,
+                                 int maxOutstandingUploadFiles) {
         return new S3TupleSink(
             s3Client,
             "bucket",
@@ -261,7 +307,9 @@ class S3TupleSinkTest {
             rotateAfterAge,
             rotateAfterTuples,
             Duration.ofMillis(10),
-            maxInFlightTuples
+            maxInFlightTuples,
+            maxOutstandingUploadBytes,
+            maxOutstandingUploadFiles
         );
     }
 }

--- a/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
+++ b/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,7 @@ class S3TupleSinkTest {
     }
 
     @Test
-    void serializationFailureCompletesOnlyThatTupleFuture() {
+    void serializationFailureCompletesOnlyThatTupleFuture() throws Exception {
         var s3Client = mock(S3AsyncClient.class);
         var recursiveTuple = new LinkedHashMap<String, Object>();
         recursiveTuple.put("self", recursiveTuple);
@@ -56,11 +57,77 @@ class S3TupleSinkTest {
             var future = new CompletableFuture<Void>();
             sink.accept(recursiveTuple, future);
 
-            assertTrue(future.isCompletedExceptionally());
-            assertThrows(ExecutionException.class, () -> future.get(1, TimeUnit.SECONDS));
+            // Serialization now runs on the worker thread (Option A), so completion is async —
+            // await it rather than asserting synchronously right after accept().
+            var ex = assertThrows(ExecutionException.class, () -> future.get(2, TimeUnit.SECONDS));
+            assertTrue(ex.getCause() instanceof IOException);
         }
 
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class));
+    }
+
+    @Test
+    void serializationRunsOffTheCallingThread() throws Exception {
+        // Option A: accept() must not serialize on the calling thread. A tuple whose toString/
+        // serialization would run on the worker should leave the calling thread immediately.
+        var s3Client = mock(S3AsyncClient.class);
+        var callingThread = Thread.currentThread().getName();
+        var serializeThread = new java.util.concurrent.CompletableFuture<String>();
+
+        // A Map whose entry iteration records the serializing thread.
+        var probeTuple = new LinkedHashMap<String, Object>() {
+            @Override
+            public java.util.Set<Map.Entry<String, Object>> entrySet() {
+                serializeThread.complete(Thread.currentThread().getName());
+                return super.entrySet();
+            }
+        };
+        probeTuple.put("connectionId", "probe.0");
+
+        try (var sink = makeSink(s3Client, 100)) {
+            sink.accept(probeTuple, new CompletableFuture<>());
+            var threadThatSerialized = serializeThread.get(2, TimeUnit.SECONDS);
+            assertFalse(threadThatSerialized.equals(callingThread),
+                "serialization should run on the sink worker, not the calling thread");
+            assertTrue(threadThatSerialized.startsWith("s3-tuple-sink-worker-"),
+                "expected the sink worker thread, got: " + threadThatSerialized);
+        }
+    }
+
+    @Test
+    void acceptBlocksWhenInFlightCapExhaustedThenProceedsAsUploadsDrain() throws Exception {
+        var s3Client = mock(S3AsyncClient.class);
+        var upload = new CompletableFuture<PutObjectResponse>();
+        when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(upload);
+
+        // Cap of 1 in-flight tuple, rotate every tuple → first accept consumes the only permit and
+        // starts an upload that we hold open; the second accept must block until that upload drains.
+        try (var sink = makeSink(s3Client, /*rotateAfterTuples*/ 1, Duration.ofMinutes(10),
+                                 /*maxInFlight*/ 1)) {
+            var f1 = new CompletableFuture<Void>();
+            sink.accept(makeTuple("conn1.0"), f1);
+
+            // Second accept on a separate thread; it should BLOCK (permit held by f1's pending upload).
+            var f2 = new CompletableFuture<Void>();
+            var secondAcceptReturned = new CompletableFuture<Void>();
+            var t = new Thread(() -> {
+                sink.accept(makeTuple("conn2.0"), f2);
+                secondAcceptReturned.complete(null);
+            }, "second-accept");
+            t.start();
+
+            // It must not return while the permit is held.
+            assertThrows(TimeoutException.class,
+                () -> secondAcceptReturned.get(500, TimeUnit.MILLISECONDS),
+                "second accept should block while the in-flight cap is exhausted");
+
+            // Drain the first upload → releases the permit → second accept proceeds.
+            upload.complete(PutObjectResponse.builder().build());
+            f1.get(2, TimeUnit.SECONDS);
+            secondAcceptReturned.get(2, TimeUnit.SECONDS);
+            t.join(2000);
+        }
     }
 
     @Test
@@ -179,6 +246,11 @@ class S3TupleSinkTest {
     }
 
     private S3TupleSink makeSink(S3AsyncClient s3Client, int rotateAfterTuples, Duration rotateAfterAge) {
+        return makeSink(s3Client, rotateAfterTuples, rotateAfterAge, S3TupleSink.DEFAULT_MAX_IN_FLIGHT_TUPLES);
+    }
+
+    private S3TupleSink makeSink(S3AsyncClient s3Client, int rotateAfterTuples, Duration rotateAfterAge,
+                                 int maxInFlightTuples) {
         return new S3TupleSink(
             s3Client,
             "bucket",
@@ -188,7 +260,8 @@ class S3TupleSinkTest {
             1024 * 1024,
             rotateAfterAge,
             rotateAfterTuples,
-            Duration.ofMillis(10)
+            Duration.ofMillis(10),
+            maxInFlightTuples
         );
     }
 }


### PR DESCRIPTION
Builds on the self-scheduled S3 tuple sink (#47). Keeps the Netty event loop healthy under load and lets the replayer ride out an S3 outage without risking replay progress.

### What changed
1. **Serialize off the event-loop thread.** `accept()` no longer JSON-serializes inline on the Netty response thread — it just estimates size, reserves backpressure permits, and enqueues; serialization/gzip/disk I/O run on the sink's worker thread.
2. **Bounded blocking backpressure.** Two gates bound the resources that grow during an S3 outage (uploads retry forever):
   - *Intake* (producer side): blocks until the tuple fits both a count cap (`maxInFlightTuples`, 100k) and a byte cap (`maxInFlightTupleBytes`, 2 GiB) — whichever fills first. Byte size is a coarse, allocation-free estimate; released when each tuple future settles.
   - *Disk backlog* (worker side): before queuing a rotated file for upload, blocks until it fits `maxOutstandingUploadFiles` (64) and `maxOutstandingUploadBytes` (1 GiB); released on upload success.
   Both **block, never fail** — failing a tuple write shuts the replayer down *without committing offsets*, so it would crash-loop on restart while S3 is down. Blocking instead throttles toward zero and resumes cleanly.
3. **Extract `ProducerLimiter`.** The four gates were duplicated hand-rolled semaphores; factored into a small tested primitive (`WeightedBlockingGate` + `ProducerLimiter`/`WeightedProducerLimiter`) in a new `…replay.limiter` package (tupleSink leaf module, no new deps). `S3TupleSink` composes four of them — no behavior change. Deliberately `ProducerLimiter`-only; `TrafficStreamLimiter`/`BlockingTrafficSource` untouched.

### Safety
No deadlock: the intake gate parks the response thread and the disk gate parks the worker, while releases run on independent SDK/retry threads (releasers never acquire); oversized inputs clamp to the cap so one big item proceeds solo. Tradeoff: during a long outage throughput goes to zero and connections are held longer — by design.

### Tests
Gate blocking/draining (count, bytes, disk), coarse size estimate, serialize-off-thread, release-once/interrupt/oversized-clamp on the new primitive. All existing `S3TupleSinkTest` pass unchanged; spotless clean.

DCO: signed off.